### PR TITLE
更新模块：占星技能优化

### DIFF
--- a/Action/ASTHelper.cs
+++ b/Action/ASTHelper.cs
@@ -761,7 +761,9 @@ public class ASTHelper : DailyModuleBase
 
         foreach (var node in ImageNodes)
             UnlinkAndFreeImageNode((AtkImageNode*)node.Value, PartyList);
+        
         ImageNodes.Clear();
+        MarkIsBuild = false;
     }
 
     private static unsafe void ResetPartyList(AtkUnitBase* partyList = null)

--- a/Action/ASTHelper.cs
+++ b/Action/ASTHelper.cs
@@ -209,7 +209,7 @@ public class ASTHelper : DailyModuleBase
                     SaveConfig(ModuleConfig);
                     NewMark(0, LuminaCache.GetRow<LuminaAction>(37023).Icon);
                     DService.Framework.RunOnTick(async () => await PreviewTimer(() => DelMark(0), 6000));
-                    RefreshMarks();
+                    RefreshMarks(true);
                 }
 
                 ImGui.TextColored(LightSalmon, GetLoc("IconOffset"));
@@ -219,7 +219,7 @@ public class ASTHelper : DailyModuleBase
                     SaveConfig(ModuleConfig);
                     NewMark(0, LuminaCache.GetRow<LuminaAction>(37023).Icon);
                     DService.Framework.RunOnTick(async () => await PreviewTimer(() => DelMark(0), 6000));
-                    RefreshMarks();
+                    RefreshMarks(true);
                 }
             }
         }
@@ -416,7 +416,7 @@ public class ASTHelper : DailyModuleBase
             return;
 
         // advance fallback when no valid zone id or invalid key
-        if (!Dal2LogsZoneMap.ContainsKey(DService.ClientState.TerritoryType) || ModuleConfig.AutoPlayCard == AutoPlayCardStatus.Advance)
+        if (!Dal2LogsZoneMap.ContainsKey(DService.ClientState.TerritoryType) && ModuleConfig.AutoPlayCard == AutoPlayCardStatus.Advance)
         {
             if (!ModuleConfig.KeyValid)
             {
@@ -761,7 +761,7 @@ public class ASTHelper : DailyModuleBase
 
         foreach (var node in ImageNodes)
             UnlinkAndFreeImageNode((AtkImageNode*)node.Value, PartyList);
-        
+
         ImageNodes.Clear();
         MarkIsBuild = false;
     }
@@ -811,12 +811,12 @@ public class ASTHelper : DailyModuleBase
             MarkNeedClear = true;
     }
 
-    private static void RefreshMarks()
+    private static void RefreshMarks(bool keptOne = false)
     {
         foreach (var (iconId, idx) in MarkedStatus)
         {
             DelMark(idx);
-            if (idx < DService.PartyList.Length || (DService.PartyList.Length is 0 && idx is 0))
+            if (idx < DService.PartyList.Length || (keptOne && DService.PartyList.Length is 0 && idx is 0))
                 NewMark(idx, iconId);
         }
     }
@@ -917,5 +917,6 @@ public class ASTHelper : DailyModuleBase
 
     #endregion
 }
+
 
 #endif


### PR DESCRIPTION
**更新说明：**

1. 移除了 Lock 的使用，使用 Concurrent 代替。
2. 更新了一些本地化说明。
3. 使用 OmenTools 中的函数创建 ImageNode。
4. 移除了 ZoneID 的缓存。
5. 调整了默认的发卡顺序，由 “全局伤害排序” 更改为 “爆发期伤害排序”。