### PR TITLE
Fix a bug when add new pet moving schedule

### DIFF
--- a/Combat/AutoMovePetPosition.cs
+++ b/Combat/AutoMovePetPosition.cs
@@ -79,7 +79,7 @@ public class AutoMovePetPosition : DailyModuleBase
             ModuleConfig.PositionSchedules[1].Add(new PositionSchedule(Guid.NewGuid().ToString())
             {
                 Enabled = true,
-                ZoneID = 0,
+                ZoneID = 1,
                 DelayS = 0,
                 Position = default
             });

--- a/Combat/AutoMovePetPosition.cs
+++ b/Combat/AutoMovePetPosition.cs
@@ -72,11 +72,11 @@ public class AutoMovePetPosition : DailyModuleBase
         ImGui.TableNextColumn();
         if (ImGuiOm.ButtonIconSelectable("AddNewPreset", FontAwesomeIcon.Plus))
         {
-            // 添加新 TerritoryId (默认等于 0)
-            if (!ModuleConfig.PositionSchedules.ContainsKey(0))
-                ModuleConfig.PositionSchedules[0] = new List<PositionSchedule>();
+            // 添加新 TerritoryId (默认等于 1)
+            if (!ModuleConfig.PositionSchedules.ContainsKey(1))
+                ModuleConfig.PositionSchedules[1] = new List<PositionSchedule>();
 
-            ModuleConfig.PositionSchedules[0].Add(new PositionSchedule(Guid.NewGuid().ToString())
+            ModuleConfig.PositionSchedules[1].Add(new PositionSchedule(Guid.NewGuid().ToString())
             {
                 Enabled = true,
                 ZoneID = 0,


### PR DESCRIPTION
Bug来源： 
https://discord.com/channels/1258981591124938762/1322043281185570838/1346101675114365019

描述：
无法新建配置  点击加号以后无法选择
![image](https://github.com/user-attachments/assets/cf4336d7-227f-43c8-a792-c9c0a503f942)

问题似乎出在如果默认的 `TerritoryId` 为 `0` 的话，
`if (!LuminaCache.TryGetRow<TerritoryType>(editingZoneID, out var zone)) continue;`
这行代码会 执行 `continue`

`TerritoryId `改成 `1` 即可恢复正常