### PR TITLE
【减伤显示】重构与小队成员信息统计

### DIFF
--- a/Action/HealerHelper.cs
+++ b/Action/HealerHelper.cs
@@ -453,7 +453,8 @@ public class HealerHelper : DailyModuleBase
                          [
                              x => () =>
                              {
-                                 if (!DService.Texture.TryGetFromGameIcon((uint)x.Icon, out var actionIcon)) return;
+                                 if (!DService.Texture.TryGetFromGameIcon((uint)x.Icon, out var actionIcon))
+                                     return;
                                  using var id = ImRaii.PushId($"{x.RowId}");
 
                                  // icon - action name
@@ -579,7 +580,8 @@ public class HealerHelper : DailyModuleBase
         ref bool  isPrevented, ref ActionType type,     ref uint actionId,
         ref ulong targetId,    ref Vector3    location, ref uint extraParam)
     {
-        if (type != ActionType.Action || GameState.IsInPVPArea || DService.PartyList.Length < 2) return;
+        if (type != ActionType.Action || GameState.IsInPVPArea || DService.PartyList.Length < 2)
+            return;
 
         // job check
         var isHealer = GameState.ClassJobData.Role == 4;
@@ -641,7 +643,8 @@ public class HealerHelper : DailyModuleBase
         try
         {
             var inPvEParty = DService.PartyList.Length > 1 && !GameState.IsInPVPArea;
-            if (!inPvEParty) return;
+            if (!inPvEParty)
+                return;
 
             // need to update candidates?
             var ids = DService.PartyList.Select(m => m.ObjectId).ToHashSet();
@@ -696,10 +699,7 @@ public class HealerHelper : DailyModuleBase
                         AutoPlayCardService.InitCustomCardOrder();
                 }
             }
-            catch (Exception ex)
-            {
-                Error($"[HealerHelper] Fetch Default Play Card Order Failed: {ex}");
-            }
+            catch (Exception ex) { Error($"[HealerHelper] Fetch Default Play Card Order Failed: {ex}"); }
         }
 
         public static async Task FetchHealActions()
@@ -719,10 +719,7 @@ public class HealerHelper : DailyModuleBase
                         EasyHealService.InitActiveHealActions();
                 }
             }
-            catch (Exception ex)
-            {
-                Error($"[HealerHelper] Fetch Default Heal Actions Failed: {ex}");
-            }
+            catch (Exception ex) { Error($"[HealerHelper] Fetch Default Heal Actions Failed: {ex}"); }
         }
 
         public static async Task FetchTerritoryMap()
@@ -739,10 +736,7 @@ public class HealerHelper : DailyModuleBase
                     FFLogsService.InitTerritoryDict();
                 }
             }
-            catch (Exception ex)
-            {
-                Error($"[HealerHelper] Fetch Territory Map Failed: {ex}");
-            }
+            catch (Exception ex) { Error($"[HealerHelper] Fetch Territory Map Failed: {ex}"); }
         }
     }
 
@@ -758,8 +752,8 @@ public class HealerHelper : DailyModuleBase
         // cache
         public HashSet<uint> PartyMemberIdsCache = []; // check party member changed or not
 
-        private readonly List<(uint id, double priority)> _meleeCandidateOrder = [];
-        private readonly List<(uint id, double priority)> _rangeCandidateOrder = [];
+        private readonly List<(uint id, double priority)> meleeCandidateOrder = [];
+        private readonly List<(uint id, double priority)> rangeCandidateOrder = [];
 
         public bool IsOpener;
         public bool NeedReorder;
@@ -826,8 +820,8 @@ public class HealerHelper : DailyModuleBase
         public void OrderCandidates()
         {
             // reset candidates before select new candidates
-            _meleeCandidateOrder.Clear();
-            _rangeCandidateOrder.Clear();
+            meleeCandidateOrder.Clear();
+            rangeCandidateOrder.Clear();
 
             // find card candidates
             var partyList = DService.PartyList; // role [1 tank, 2 melee, 3 range, 4 healer]
@@ -863,16 +857,16 @@ public class HealerHelper : DailyModuleBase
             for (var idx = 0; idx < meleeOrder.Length; idx++)
             {
                 var member = partyList.FirstOrDefault(m => m.ClassJob.Value.NameEnglish == meleeOrder[idx]);
-                if (member is not null && _meleeCandidateOrder.All(m => m.id != member.ObjectId))
-                    _meleeCandidateOrder.Add((member.ObjectId, 2 - (idx * 0.1)));
+                if (member is not null && meleeCandidateOrder.All(m => m.id != member.ObjectId))
+                    meleeCandidateOrder.Add((member.ObjectId, 2 - (idx * 0.1)));
             }
 
             var rangeOrder = activateOrder.Range[sectionLabel];
             for (var idx = 0; idx < rangeOrder.Length; idx++)
             {
                 var member = partyList.FirstOrDefault(m => m.ClassJob.Value.NameEnglish == rangeOrder[idx]);
-                if (member is not null && _rangeCandidateOrder.All(m => m.id != member.ObjectId))
-                    _rangeCandidateOrder.Add((member.ObjectId, 2 - (idx * 0.1)));
+                if (member is not null && rangeCandidateOrder.All(m => m.id != member.ObjectId))
+                    rangeCandidateOrder.Add((member.ObjectId, 2 - (idx * 0.1)));
             }
 
             // adjust candidate priority based on FFLogs records (auto play card advance mode)
@@ -881,7 +875,8 @@ public class HealerHelper : DailyModuleBase
                 foreach (var member in partyList)
                 {
                     var bestRecord = FFLogsService.FetchBestRecord((ushort)GameState.TerritoryType, member).GetAwaiter().GetResult();
-                    if (bestRecord is null) continue;
+                    if (bestRecord is null)
+                        continue;
 
                     // scale priority based on sigmoid percentile
                     var scale = 1 / (1 + Math.Exp(-(bestRecord.Percentile - 50) / 8.33));
@@ -891,22 +886,22 @@ public class HealerHelper : DailyModuleBase
                         // update priority
                         case 1 or 2:
                         {
-                            var idx = _meleeCandidateOrder.FindIndex(m => m.id == member.ObjectId);
+                            var idx = meleeCandidateOrder.FindIndex(m => m.id == member.ObjectId);
                             if (idx != -1)
                             {
-                                var priority = _meleeCandidateOrder[idx].priority * scale;
-                                _meleeCandidateOrder[idx] = (member.ObjectId, priority);
+                                var priority = meleeCandidateOrder[idx].priority * scale;
+                                meleeCandidateOrder[idx] = (member.ObjectId, priority);
                             }
 
                             break;
                         }
                         case 3:
                         {
-                            var idx = _rangeCandidateOrder.FindIndex(m => m.id == member.ObjectId);
+                            var idx = rangeCandidateOrder.FindIndex(m => m.id == member.ObjectId);
                             if (idx != -1)
                             {
-                                var priority = _rangeCandidateOrder[idx].priority * scale;
-                                _rangeCandidateOrder[idx] = (member.ObjectId, priority);
+                                var priority = rangeCandidateOrder[idx].priority * scale;
+                                rangeCandidateOrder[idx] = (member.ObjectId, priority);
                             }
 
                             break;
@@ -916,31 +911,31 @@ public class HealerHelper : DailyModuleBase
             }
 
             // fallback: select the first dps in party list
-            if (_meleeCandidateOrder.Count is 0)
+            if (meleeCandidateOrder.Count is 0)
             {
                 var firstRange = partyList.FirstOrDefault(m => m.ClassJob.Value.Role is 1 or 3);
                 if (firstRange is not null)
-                    _meleeCandidateOrder.Add((firstRange.ObjectId, -5));
+                    meleeCandidateOrder.Add((firstRange.ObjectId, -5));
             }
 
-            if (_rangeCandidateOrder.Count is 0)
+            if (rangeCandidateOrder.Count is 0)
             {
                 var firstMelee = partyList.FirstOrDefault(m => m.ClassJob.Value.Role is 2);
                 if (firstMelee is not null)
-                    _rangeCandidateOrder.Add((firstMelee.ObjectId, -5));
+                    rangeCandidateOrder.Add((firstMelee.ObjectId, -5));
             }
 
             // sort candidates by priority
-            _meleeCandidateOrder.Sort((a, b) => b.priority.CompareTo(a.priority));
-            _rangeCandidateOrder.Sort((a, b) => b.priority.CompareTo(a.priority));
+            meleeCandidateOrder.Sort((a, b) => b.priority.CompareTo(a.priority));
+            rangeCandidateOrder.Sort((a, b) => b.priority.CompareTo(a.priority));
         }
 
         private uint FetchCandidateId(string role)
         {
             var candidates = role switch
             {
-                "Melee" => _meleeCandidateOrder,
-                "Range" => _rangeCandidateOrder,
+                "Melee" => meleeCandidateOrder,
+                "Range" => rangeCandidateOrder,
                 _ => throw new ArgumentOutOfRangeException(nameof(role))
             };
 
@@ -949,7 +944,8 @@ public class HealerHelper : DailyModuleBase
             {
                 var member    = candidates[i];
                 var candidate = DService.PartyList.FirstOrDefault(m => m.ObjectId == member.id);
-                if (candidate is null) continue;
+                if (candidate is null)
+                    continue;
 
                 // skip dead member in this round (refresh on duty recommenced)
                 if (candidate.CurrentHP <= 0)
@@ -957,10 +953,10 @@ public class HealerHelper : DailyModuleBase
                     switch (role)
                     {
                         case "Melee":
-                            _meleeCandidateOrder[i] = (candidate.ObjectId, -2);
+                            meleeCandidateOrder[i] = (candidate.ObjectId, -2);
                             break;
                         case "Range":
-                            _rangeCandidateOrder[i] = (candidate.ObjectId, -2);
+                            rangeCandidateOrder[i] = (candidate.ObjectId, -2);
                             break;
                     }
 
@@ -1146,8 +1142,10 @@ public class HealerHelper : DailyModuleBase
             // first dispel local player
             var localStatus = DService.ClientState.LocalPlayer.StatusList;
             foreach (var status in localStatus)
+            {
                 if (PresetSheet.DispellableStatuses.ContainsKey(status.StatusId))
                     return GameState.EntityID;
+            }
 
             // dispel in order (or reverse order)
             var sortedPartyList = reverse
@@ -1162,8 +1160,10 @@ public class HealerHelper : DailyModuleBase
                     continue;
 
                 foreach (var status in member.Statuses)
+                {
                     if (PresetSheet.DispellableStatuses.ContainsKey(status.StatusId))
                         return member.ObjectId;
+                }
             }
 
             return UnspecificTargetId;
@@ -1377,10 +1377,7 @@ public class HealerHelper : DailyModuleBase
                 config.KeyValid   = !string.IsNullOrWhiteSpace(response);
                 FirstTimeFallback = true;
             }
-            catch (Exception)
-            {
-                config.KeyValid = false;
-            }
+            catch (Exception) { config.KeyValid = false; }
         }
 
         private static string FetchRegion()
@@ -1419,7 +1416,8 @@ public class HealerHelper : DailyModuleBase
                 // contains all ultimates and current savage in current version
                 var response = await HttpClientHelper.Get().GetStringAsync($"{uri}?{query}");
                 var records  = JsonConvert.DeserializeObject<LogsRecord[]>(response);
-                if (records == null || records.Length == 0) return null;
+                if (records == null || records.Length == 0)
+                    return null;
 
                 // find best record
                 bestRecord = records.Where(r => r.JobName == job)
@@ -1429,10 +1427,7 @@ public class HealerHelper : DailyModuleBase
                 MemberBestRecords[member.ObjectId] = bestRecord;
                 return bestRecord;
             }
-            catch (Exception)
-            {
-                return null;
-            }
+            catch (Exception) { return null; }
         }
 
         public void ClearBestRecords()
@@ -1445,7 +1440,6 @@ public class HealerHelper : DailyModuleBase
     }
 
     #endregion
-
 
     #region Config
 

--- a/Combat/AutoDisplayMitigationInfo.cs
+++ b/Combat/AutoDisplayMitigationInfo.cs
@@ -22,6 +22,7 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 {
     #region Core
 
+    // info
     public override ModuleInfo Info { get; } = new()
     {
         Title       = GetLoc("AutoDisplayMitigationInfoTitle"),
@@ -30,17 +31,12 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         Author      = ["HaKu"]
     };
 
-    // icon asset
+    // storage
+    private static ModuleStorage? ModuleConfig;
+
+    // asset
     private static readonly byte[] DamagePhysicalStr;
     private static readonly byte[] DamageMagicalStr;
-
-    // config & overlay
-    private static Config        ModuleConfig = null!;
-    private static IDtrBarEntry? BarEntry;
-
-    // cache variables
-    private static Dictionary<uint, MitigationStatus>  MitigationStatusMap  = [];
-    private static Dictionary<MitigationStatus, float> LastMitigationStatus = [];
 
     static AutoDisplayMitigationInfo()
     {
@@ -48,16 +44,175 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         DamageMagicalStr  = new SeString(new IconPayload(BitmapFontIcon.DamageMagical)).Encode();
     }
 
+    // managers
+    public static MitigationManager MitigationService;
+
     public override void Init()
     {
-        ModuleConfig = LoadConfig<Config>() ?? new();
+        ModuleConfig = LoadConfig<ModuleStorage>() ?? new ModuleStorage();
+
+        // enable cast hooks
+        DamageActionManager.Enable();
 
         // overlay
+        SetOverlay();
+
+        // status bar
+        StatusBarManager.Enable();
+        StatusBarManager.BarEntry.OnClick = () =>
+        {
+            if (Overlay == null) return;
+            Overlay.IsOpen ^= true;
+        };
+
+        // cast bar
+        CastBarManager.Enable();
+
+        // party list
+        PartyListManager.Enable();
+
+        // fetch remote resource
+        Task.Run(async () =>
+        {
+            await RemoteRepoManager.FetchMitigationStatuses();
+            await RemoteRepoManager.FetchDamageActions();
+        });
+        SaveConfig(ModuleConfig);
+
+        // managers
+        MitigationService = new MitigationManager(ModuleConfig.MitigationStorage);
+
+        // life cycle hooks
+        DService.ClientState.TerritoryChanged += OnZoneChanged;
+        FrameworkManager.Register(OnFrameworkUpdate);
+        FrameworkManager.Register(OnFrameworkUpdateInterval, throttleMS: 500);
+    }
+
+    public override void Uninit()
+    {
+        // life cycle hooks
+        DService.ClientState.TerritoryChanged -= OnZoneChanged;
+        FrameworkManager.Unregister(OnFrameworkUpdate);
+        FrameworkManager.Unregister(OnFrameworkUpdateInterval);
+
+        // status bar
+        StatusBarManager.Disable();
+
+        // cast bar
+        CastBarManager.Disable();
+
+        // party list
+        PartyListManager.Disable();
+
+        // disable cast hooks
+        DamageActionManager.Disable();
+
+        base.Uninit();
+    }
+
+    public override void ConfigUI()
+    {
+        if (ImGui.Checkbox(GetLoc("OnlyInCombat"), ref ModuleConfig.OnlyInCombat))
+            SaveConfig(ModuleConfig);
+
+        if (ImGui.Checkbox(GetLoc("TransparentOverlay"), ref ModuleConfig.TransparentOverlay))
+        {
+            SaveConfig(ModuleConfig);
+
+            if (ModuleConfig.TransparentOverlay)
+            {
+                Overlay.Flags |= ImGuiWindowFlags.NoBackground;
+                Overlay.Flags |= ImGuiWindowFlags.NoTitleBar;
+            }
+            else
+            {
+                Overlay.Flags &= ~ImGuiWindowFlags.NoBackground;
+                Overlay.Flags &= ~ImGuiWindowFlags.NoTitleBar;
+            }
+        }
+
+        if (ImGui.Checkbox(GetLoc("ResizeableOverlay"), ref ModuleConfig.ResizeableOverlay))
+        {
+            SaveConfig(ModuleConfig);
+
+            if (ModuleConfig.ResizeableOverlay)
+                Overlay.Flags &= ~ImGuiWindowFlags.NoResize;
+            else
+                Overlay.Flags |= ImGuiWindowFlags.NoResize;
+        }
+
+        if (ImGui.Checkbox(GetLoc("MoveableOverlay"), ref ModuleConfig.MoveableOverlay))
+        {
+            SaveConfig(ModuleConfig);
+
+            if (!ModuleConfig.MoveableOverlay)
+            {
+                Overlay.Flags |= ImGuiWindowFlags.NoMove;
+                Overlay.Flags |= ImGuiWindowFlags.NoInputs;
+            }
+            else
+            {
+                Overlay.Flags &= ~ImGuiWindowFlags.NoMove;
+                Overlay.Flags &= ~ImGuiWindowFlags.NoInputs;
+            }
+        }
+    }
+
+    #endregion
+
+    #region Overlay
+
+    public override unsafe void OverlayUI()
+    {
+        if (Control.GetLocalPlayer() == null || MitigationService.IsLocalEmpty()) return;
+
+        ImGuiHelpers.SeStringWrapped(StatusBarManager.BarEntry?.Text?.Encode() ?? []);
+
+        ImGui.Separator();
+
+        using var table = ImRaii.Table("StatusTable", 3);
+        if (!table) return;
+
+        ImGui.TableSetupColumn("Icon", ImGuiTableColumnFlags.WidthFixed, 24f * GlobalFontScale);
+        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 20);
+        ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 20);
+
+        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon)) return;
+
+        // local status
+        foreach (var status in MitigationService.LocalActiveStatus)
+            DrawStatusRow(status);
+
+        // battle npc status
+        foreach (var status in MitigationService.BattleNpcActiveStatus)
+            DrawStatusRow(status);
+
+        // local shield
+        if (MitigationService.LocalShield > 0)
+        {
+            if (!MitigationService.IsLocalEmpty())
+                ImGui.TableNextRow();
+
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Image(barrierIcon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
+
+            ImGui.TableNextColumn();
+            ImGui.AlignTextToFramePadding();
+            ImGui.Text($"{GetLoc("Shield")}");
+
+            ImGui.TableNextColumn();
+            ImGui.Text($"{MitigationService.LocalShield}");
+        }
+    }
+
+    private void SetOverlay()
+    {
         Overlay            ??= new(this);
         Overlay.WindowName =   GetLoc("AutoDisplayMitigationInfoTitle");
         Overlay.Flags      &=  ~ImGuiWindowFlags.NoTitleBar;
         Overlay.Flags      &=  ~ImGuiWindowFlags.AlwaysAutoResize;
-        
+
         if (ModuleConfig.TransparentOverlay)
         {
             Overlay.Flags |= ImGuiWindowFlags.NoBackground;
@@ -84,398 +239,1066 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             Overlay.Flags &= ~ImGuiWindowFlags.NoMove;
             Overlay.Flags &= ~ImGuiWindowFlags.NoInputs;
         }
-        
-        // status bar
-        BarEntry ??= DService.DtrBar.Get("DailyRoutines-AutoDisplayMitigationInfo");
-        BarEntry.OnClick = () =>
-        {
-            if (Overlay == null) return;
-            Overlay.IsOpen ^= true;
-        };
+    }
 
-        // fetch remote resources
-        DService.Framework.RunOnTick(async () => await FetchRemoteVersion());
+    private static void DrawStatusRow(KeyValuePair<MitigationManager.Status, float> status)
+    {
+        if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row)) return;
+        if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon)) return;
 
-        // life cycle hooks
-        FrameworkManager.Register(OnFrameworkUpdate, throttleMS: 500);
+        ImGui.TableNextRow();
+
+        ImGui.TableNextColumn();
+        ImGui.Image(icon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
+
+        ImGui.TableNextColumn();
+        ImGui.AlignTextToFramePadding();
+        ImGui.Text($"{row.Name} ({status.Value:F1}s)");
+        ImGuiOm.TooltipHover($"{status.Key.Id}");
+
+        ImGui.TableNextColumn();
+        ImGuiHelpers.SeStringWrapped(DamagePhysicalStr);
+
+        ImGui.SameLine();
+        ImGui.Text($"{status.Key.Info.Physical}% ");
+
+        ImGui.SameLine();
+        ImGuiHelpers.SeStringWrapped(DamageMagicalStr);
+
+        ImGui.SameLine();
+        ImGui.Text($"{status.Key.Info.Magical}% ");
     }
 
     #endregion
 
-    #region UI
-
-    public override void ConfigUI()
-    {
-        if (ImGui.Checkbox(GetLoc("OnlyInCombat"), ref ModuleConfig.OnlyInCombat))
-            SaveConfig(ModuleConfig);
-
-        if (ImGui.Checkbox(GetLoc("TransparentOverlay"), ref ModuleConfig.TransparentOverlay))
-        {
-            SaveConfig(ModuleConfig);
-
-            if (ModuleConfig.TransparentOverlay)
-            {
-                Overlay.Flags |= ImGuiWindowFlags.NoBackground;
-                Overlay.Flags |= ImGuiWindowFlags.NoTitleBar;
-            }
-            else
-            {
-                Overlay.Flags &= ~ImGuiWindowFlags.NoBackground;
-                Overlay.Flags &= ~ImGuiWindowFlags.NoTitleBar;
-            }
-        }
-        
-        if (ImGui.Checkbox(GetLoc("ResizeableOverlay"), ref ModuleConfig.ResizeableOverlay))
-        {
-            SaveConfig(ModuleConfig);
-
-            if (ModuleConfig.ResizeableOverlay)
-                Overlay.Flags &= ~ImGuiWindowFlags.NoResize;
-            else
-                Overlay.Flags |= ImGuiWindowFlags.NoResize;
-        }
-        
-        if (ImGui.Checkbox(GetLoc("MoveableOverlay"), ref ModuleConfig.MoveableOverlay))
-        {
-            SaveConfig(ModuleConfig);
-
-            if (!ModuleConfig.MoveableOverlay)
-            {
-                Overlay.Flags |= ImGuiWindowFlags.NoMove;
-                Overlay.Flags |= ImGuiWindowFlags.NoInputs;
-            }
-            else
-            {
-                Overlay.Flags &= ~ImGuiWindowFlags.NoMove;
-                Overlay.Flags &= ~ImGuiWindowFlags.NoInputs;
-            }
-        }
-    }
-
-    public override unsafe void OverlayUI()
-    {
-        var localPlayer = Control.GetLocalPlayer();
-        if (localPlayer == null) return;
-        
-        if (LastMitigationStatus.Count == 0 && localPlayer->ShieldValue == 0) return;
-
-        ImGuiHelpers.SeStringWrapped(BarEntry?.Text?.Encode() ?? []);
-
-        ImGui.Separator();
-
-        using var table = ImRaii.Table("StatusTable", 3);
-
-        if (!table) return;
-
-        ImGui.TableSetupColumn("图标", ImGuiTableColumnFlags.WidthFixed,   24f * GlobalFontScale);
-        ImGui.TableSetupColumn("名字", ImGuiTableColumnFlags.WidthStretch, 20);
-        ImGui.TableSetupColumn("数字", ImGuiTableColumnFlags.WidthStretch, 20);
-
-        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon)) return;
-
-        foreach (var status in LastMitigationStatus)
-        {
-            if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row)) continue;
-            if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon)) continue;
-
-            ImGui.TableNextRow();
-
-            ImGui.TableNextColumn();
-            ImGui.Image(icon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
-
-            ImGui.TableNextColumn();
-            ImGui.AlignTextToFramePadding();
-            ImGui.Text($"{row.Name} ({status.Value:F1}s)");
-            ImGuiOm.TooltipHover($"{status.Key.Id}");
-
-            ImGui.TableNextColumn();
-            ImGuiHelpers.SeStringWrapped(DamagePhysicalStr);
-
-            ImGui.SameLine();
-            ImGui.Text($"{status.Key.Mitigation.Physical}% ");
-
-            ImGui.SameLine();
-            ImGuiHelpers.SeStringWrapped(DamageMagicalStr);
-
-            ImGui.SameLine();
-            ImGui.Text($"{status.Key.Mitigation.Magical}% ");
-        }
-
-        var shieldValue = localPlayer->ShieldValue;
-        if (shieldValue > 0)
-        {
-            if (LastMitigationStatus.Count > 0)
-                ImGui.TableNextRow();
-
-            ImGui.TableNextRow();
-            ImGui.TableNextColumn();
-            ImGui.Image(barrierIcon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
-
-            ImGui.TableNextColumn();
-            ImGui.AlignTextToFramePadding();
-            ImGui.Text($"{GetLoc("Shield")}");
-
-            ImGui.TableNextColumn();
-            var shieldPercentage = (double)shieldValue / 100;
-            ImGui.Text($"{shieldValue}%% ({localPlayer->Health * shieldPercentage:F0})");
-        }
-    }
-
-    #endregion
-
-    public override void Uninit()
-    {
-        FrameworkManager.Unregister(OnFrameworkUpdate);
-
-        BarEntry?.Remove();
-        BarEntry = null;
-
-        base.Uninit();
-    }
 
     #region Hooks
 
-    public static unsafe void OnFrameworkUpdate(IFramework _)
+    public static void OnFrameworkUpdate(IFramework _)
     {
-        if (DService.ClientState.IsPvP || (ModuleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat]))
+        var combatInactive = ModuleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat];
+        if (DService.ClientState.IsPvP || combatInactive || DService.ClientState.LocalPlayer is null)
         {
-            ClearAndCloseBarEntry();
+            StatusBarManager.Clear();
             return;
         }
 
-        if (DService.ClientState.LocalPlayer is not { } localPlayer)
+        // update status
+        CastBarManager.Update();
+        PartyListManager.Update();
+    }
+
+    public static void OnFrameworkUpdateInterval(IFramework _)
+    {
+        var combatInactive = ModuleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat];
+        if (DService.ClientState.IsPvP || combatInactive || DService.ClientState.LocalPlayer is null)
         {
-            ClearAndCloseBarEntry();
+            StatusBarManager.Clear();
             return;
         }
 
-        Dictionary<MitigationStatus, float> lastMitigationStatus = [];
-
-        var localPlayerStatus = localPlayer.StatusList;
-        foreach (var status in localPlayerStatus)
-            if (MitigationStatusMap.TryGetValue(status.StatusId, out var mitigation))
-                lastMitigationStatus.Add(mitigation, status.RemainingTime);
-
-        var currentTarget = DService.Targets.Target;
-        if (currentTarget is IBattleNpc battleNpc)
-        {
-            var statusList = battleNpc.ToBCStruct()->StatusManager.Status;
-            foreach (var status in statusList)
-                if (MitigationStatusMap.TryGetValue(status.StatusId, out var mitigation))
-                    lastMitigationStatus.Add(mitigation, status.RemainingTime);
-        }
-
-        LastMitigationStatus = lastMitigationStatus.ToDictionary(x => x.Key, x => x.Value);
-        if (LastMitigationStatus.Count == 0 && localPlayer.ShieldPercentage == 0)
-        {
-            ClearAndCloseBarEntry();
-            return;
-        }
-
-        RefreshBarEntry(LastMitigationStatus);
+        // update status
+        MitigationService.Update();
+        StatusBarManager.Update();
     }
 
-    #endregion
-
-    #region StatusBar
-
-    private static unsafe void RefreshBarEntry(Dictionary<MitigationStatus, float> statuses)
-    {
-        if (BarEntry == null) return;
-
-        var localPlayer = Control.GetLocalPlayer();
-        if (localPlayer == null) return;
-
-        var textBuildr = new SeStringBuilder();
-        var values = new[]
-        {
-            MitigationReduction(statuses.Keys.Select(x => x.Mitigation.Physical)),
-            MitigationReduction(statuses.Keys.Select(x => x.Mitigation.Magical)),
-            localPlayer->Character.ShieldValue,
-        };
-
-        for (var i = 0; i < values.Length; i++)
-        {
-            if (values[i] <= 0) continue;
-
-            var icon = i switch
-            {
-                0 => BitmapFontIcon.DamagePhysical,
-                1 => BitmapFontIcon.DamageMagical,
-                2 => BitmapFontIcon.Tank,
-                _ => BitmapFontIcon.None,
-            };
-
-            if (i != 0) textBuildr.Append(" ");
-            textBuildr.AddIcon(icon);
-            textBuildr.Append($"{values[i]:0.0}%");
-        }
-
-        textBuildr.Append($" ({statuses.Count})");
-        BarEntry.Text = textBuildr.Build();
-
-        var tooltipBuilder = new SeStringBuilder();
-        foreach (var (status, _) in LastMitigationStatus)
-        {
-            tooltipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)} ({status.Id}):");
-            tooltipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
-            tooltipBuilder.Append($"{status.Mitigation.Physical}% ");
-            tooltipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
-            tooltipBuilder.Append($"{status.Mitigation.Magical}% ");
-            tooltipBuilder.Append("\n");
-        }
-
-        var shieldPercentage = (double)localPlayer->ShieldValue / 100;
-        if (localPlayer->ShieldValue > 0)
-        {
-            if (statuses.Count > 0)
-                tooltipBuilder.Append("\n");
-
-            tooltipBuilder.AddIcon(BitmapFontIcon.Tank);
-            tooltipBuilder.Append($"{GetLoc("Shield")}: {values[2]}% ({localPlayer->Health * shieldPercentage:F0})");
-        }
-
-        var built = tooltipBuilder.Build();
-        // remove last \n when no shield
-        if (localPlayer->ShieldValue == 0)
-            built.Payloads.RemoveAt(built.Payloads.Count - 1);
-
-        BarEntry.Tooltip = tooltipBuilder.Build();
-
-        BarEntry.Shown = true;
-    }
-
-    private static void ClearAndCloseBarEntry()
-    {
-        if (BarEntry == null) return;
-
-        BarEntry.Shown   = false;
-        BarEntry.Tooltip = null;
-        BarEntry.Text    = null;
-    }
-
-    #endregion
-
-    #region Func
-
-    private static float MitigationReduction(IEnumerable<float> mitigations) =>
-        (1f - mitigations.Aggregate(1f, (acc, m) => acc * (1f - (m / 100f)))) * 100f;
-
-    private static void UpdateMitigationStatusMap()
-        => MitigationStatusMap = ModuleConfig.MitigationStatuses.ToDictionary(s => s.Id);
+    private static void OnZoneChanged(ushort zoneId)
+        => RemoteRepoManager.FetchDamageActions(zoneId);
 
     #endregion
 
     #region RemoteCache
 
-    // cache related client setting
-    private const string SuCache = "https://dr-cache.sumemo.dev";
-
-    private async Task FetchRemoteVersion()
+    public static class RemoteRepoManager
     {
-        // fetch remote data
-        try
-        {
-            var json = await HttpClientHelper.Get().GetStringAsync($"{SuCache}/version");
-            var resp = JsonConvert.DeserializeAnonymousType(json, new { version = "" });
-            if (resp == null || string.IsNullOrWhiteSpace(resp.version))
-                Error($"Deserialize Remote Version Failed: {json}");
-            else
-            {
-                // fetch remote data
-                var remoteCacheVersion = resp.version;
-                if (new Version(ModuleConfig.LocalCacheVersion) < new Version(remoteCacheVersion))
-                {
-                    // update config
-                    ModuleConfig.LocalCacheVersion = resp.version;
-                    SaveConfig(ModuleConfig);
+        // const
+        private const string Uri = "https://dr-cache.sumemo.dev";
 
-                    // update out-date cache
-                    await FetchMitigationStatuses();
+        public static async Task FetchMitigationStatuses()
+        {
+            try
+            {
+                var json = await HttpClientHelper.Get().GetStringAsync($"{Uri}/mitigation");
+                var resp = JsonConvert.DeserializeObject<MitigationManager.Status[]>(json);
+                if (resp == null)
+                    Error($"[AutoDisplayMitigationInfo] Deserialize Mitigation List Failed: {json}");
+                else
+                {
+                    ModuleConfig.MitigationStorage.Statuses = resp;
+                    MitigationService.InitStatusMap();
                 }
             }
-        }
-        catch (Exception ex)
-        {
-            Error($"[AutoDisplayMitigationInfo] Fetch Remote Version Failed: {ex}");
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] Fetch Mitigation List Failed: {ex}"); }
         }
 
-        // build cache
-        UpdateMitigationStatusMap();
+        // TODO: separate by zone
+        private static DamageActionManager.DamageAction[] Actions = [];
+
+        public static async Task FetchDamageActions()
+        {
+            try
+            {
+                var json = await HttpClientHelper.Get().GetStringAsync($"{Uri}/damage");
+                var resp = JsonConvert.DeserializeObject<DamageActionManager.DamageAction[]>(json);
+                if (resp == null)
+                    Error($"[AutoDisplayMitigationInfo] Deserialize Damage Action List Failed: {json}");
+                else
+                    Actions = resp;
+            }
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] Fetch Damage Action List Failed: {ex}"); }
+        }
+
+        public static void FetchDamageActions(uint zoneId)
+            => DamageActionManager.Actions = Actions.Where(x => x.ZoneId == zoneId).ToDictionary(x => x.ActionId, x => x);
     }
 
-    private async Task FetchMitigationStatuses()
+    #endregion
+
+
+    #region StatusBar
+
+    public static class StatusBarManager
     {
-        try
+        // cache
+        public static IDtrBarEntry? BarEntry;
+
+        #region Funcs
+
+        public static void Enable()
+            => BarEntry ??= DService.DtrBar.Get("DailyRoutines-AutoDisplayMitigationInfo");
+
+        public static void Update()
         {
-            var json = await HttpClientHelper.Get().GetStringAsync($"{SuCache}/mitigation?v={ModuleConfig.LocalCacheVersion}");
-            var resp = JsonConvert.DeserializeObject<MitigationStatus[]>(json);
-            if (resp == null)
-                Error($"[AutoDisplayMitigationInfo] Deserialize Mitigation List Failed: {json}");
-            else
+            if (BarEntry == null || MitigationService.IsLocalEmpty())
             {
-                ModuleConfig.MitigationStatuses = resp;
-                SaveConfig(ModuleConfig);
+                Clear();
+                return;
+            }
+
+            // summary
+            var textBuilder  = new SeStringBuilder();
+            var values       = MitigationService.FetchLocal();
+            var firstBarItem = true;
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                if (values[i] <= 0) continue;
+
+                var icon = i switch
+                {
+                    0 => BitmapFontIcon.DamagePhysical,
+                    1 => BitmapFontIcon.DamageMagical,
+                    2 => BitmapFontIcon.Tank,
+                    _ => BitmapFontIcon.None,
+                };
+
+                if (!firstBarItem) textBuilder.Append(" ");
+                textBuilder.AddIcon(icon);
+                textBuilder.Append($"{values[i]:0}" + (i != 2 ? "%" : ""));
+                firstBarItem = false;
+            }
+
+            BarEntry.Text = textBuilder.Build();
+
+            // detail
+            var tipBuilder   = new SeStringBuilder();
+            var firstTipItem = true;
+
+            // status
+            foreach (var (status, _) in MitigationService.LocalActiveStatus)
+            {
+                if (!firstTipItem) tipBuilder.Append("\n");
+                tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
+                tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
+                tipBuilder.Append($"{status.Info.Physical}% ");
+                tipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
+                tipBuilder.Append($"{status.Info.Magical}% ");
+                firstTipItem = false;
+            }
+
+            // shield
+            if (MitigationService.LocalShield > 0)
+            {
+                if (!firstTipItem) tipBuilder.Append("\n");
+                tipBuilder.AddIcon(BitmapFontIcon.Tank);
+                tipBuilder.Append($"{GetLoc("Shield")}: {MitigationService.LocalShield}");
+                firstTipItem = false;
+            }
+
+            // battle npc
+            foreach (var (status, _) in MitigationService.BattleNpcActiveStatus)
+            {
+                if (!firstTipItem) tipBuilder.Append("\n");
+                tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
+                tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
+                tipBuilder.Append($"{status.Info.Physical}% ");
+                tipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
+                tipBuilder.Append($"{status.Info.Magical}% ");
+                firstTipItem = false;
+            }
+
+            BarEntry.Tooltip = tipBuilder.Build();
+            BarEntry.Shown   = true;
+        }
+
+        public static void Clear()
+        {
+            if (BarEntry == null) return;
+
+            BarEntry.Shown   = false;
+            BarEntry.Tooltip = null;
+            BarEntry.Text    = null;
+        }
+
+        public static void Disable()
+        {
+            BarEntry?.Remove();
+            BarEntry = null;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region CastBar
+
+    public static class CastBarManager
+    {
+        // const
+        private const uint NodeId = 25;
+
+        #region Funcs
+
+        public static unsafe void Enable()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_TargetInfoCastBar");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            var castBar = addon->GetNodeById(2);
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null && !TryMakeTextNode(NodeId, out node))
+                return;
+
+            node->FontSize = 10;
+            node->AtkResNode.SetWidth(200);
+            node->AtkResNode.SetHeight(castBar->GetHeight());
+            node->ToggleVisibility(false);
+            node->SetPositionShort(
+                (short)(castBar->GetXShort() + castBar->GetWidth()),
+                castBar->GetYShort()
+            );
+            node->DrawFlags       |= 1;
+            node->TextFlags       =  8;
+            node->TextFlags2      =  0;
+            node->FontType        =  FontType.MiedingerMed;
+            node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+            node->EdgeColor       =  new ByteColor { R = 255, G = 0, B   = 162, A = 157 };
+            node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+            node->AlignmentType   =  AlignmentType.BottomLeft;
+
+            LinkNodeAtEnd((AtkResNode*)node, addon);
+        }
+
+        public static unsafe void Disable()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_TargetInfoCastBar");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            var node = FetchNode(NodeId, addon);
+            if (node == null) return;
+            UnlinkAndFreeTextNode((AtkTextNode*)node, addon);
+        }
+
+        public static unsafe void Update()
+        {
+            if (DamageActionManager.CurrentAction.ActionId == 0)
+            {
+                Clear();
+                return;
+            }
+
+            var addonPtr = DService.Gui.GetAddonByName("_TargetInfoCastBar");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null) return;
+
+            node->ToggleVisibility(true);
+            node->SetText(DamageActionManager.FetchLocalDamage().ToString("N0"));
+        }
+
+        public static unsafe void Clear()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_TargetInfoCastBar");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null) return;
+
+            node->ToggleVisibility(false);
+        }
+
+        private static unsafe AtkResNode* FetchNode(uint nodeId, AtkUnitBase* addon)
+        {
+            for (var i = 0; i < addon->UldManager.NodeListCount; i++)
+            {
+                var t = addon->UldManager.NodeList[i];
+                if (t->NodeId == nodeId)
+                    return t;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region PartyList
+
+    public static class PartyListManager
+    {
+        // const
+        private const uint MitigationNodeId = 2025;
+        private const uint ShieldNodeId     = 2026;
+
+        #region Funcs
+
+        public static unsafe void Enable()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_PartyList");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            EnableMitigationNodes(addon);
+            EnableShieldNodes(addon);
+        }
+
+        private static unsafe void EnableMitigationNodes(AtkUnitBase* addon)
+        {
+            foreach (uint i in Enumerable.Range(10, 8))
+            {
+                var memberNode = addon->GetComponentNodeById(i)->Component;
+                var plateNode  = FetchNode(14, memberNode);
+
+                var node = (AtkTextNode*)FetchNode(MitigationNodeId, memberNode);
+                if (node == null && !TryMakeTextNode(MitigationNodeId, out node))
+                    continue;
+
+                node->FontSize = 10;
+                node->AtkResNode.SetWidth(plateNode->Width);
+                node->AtkResNode.SetHeight(plateNode->Height);
+                node->ToggleVisibility(false);
+                node->SetPositionShort(
+                    (short)(plateNode->GetXShort() - 5),
+                    (short)(plateNode->GetYShort() + 3)
+                );
+                node->DrawFlags       |= 1;
+                node->TextFlags       =  8;
+                node->TextFlags2      =  0;
+                node->FontType        =  FontType.MiedingerMed;
+                node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+                node->EdgeColor       =  new ByteColor { R = 255, G = 162, B = 0, A   = 157 };
+                node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+                node->AlignmentType   =  AlignmentType.TopRight;
+
+                LinkNodeAtEnd((AtkResNode*)node, memberNode);
             }
         }
-        catch (Exception ex)
+
+        private static unsafe void EnableShieldNodes(AtkUnitBase* addon)
         {
-            Error($"[AutoDisplayMitigationInfo] Fetch Mitigation List Failed: {ex}");
+            foreach (uint i in Enumerable.Range(10, 8))
+            {
+                var memberNode = addon->GetComponentNodeById(i)->Component;
+                var hpNode     = FetchNode(12, memberNode)->GetAsAtkComponentNode()->Component;
+                var numNode    = FetchNode(2, hpNode);
+
+                var node = (AtkTextNode*)FetchNode(ShieldNodeId, hpNode);
+                if (node == null && !TryMakeTextNode(ShieldNodeId, out node))
+                    continue;
+
+                node->FontSize = 8;
+                node->AtkResNode.SetWidth(20);
+                node->AtkResNode.SetHeight(numNode->Height);
+                node->ToggleVisibility(false);
+                node->SetPositionShort(
+                    (short)(numNode->GetXShort() + numNode->GetWidth() + 2),
+                    (short)(numNode->GetYShort() + 3)
+                );
+                node->DrawFlags       |= 1;
+                node->TextFlags       =  8;
+                node->TextFlags2      =  0;
+                node->FontType        =  FontType.MiedingerMed;
+                node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+                node->EdgeColor       =  new ByteColor { R = 255, G = 162, B = 0, A   = 157 };
+                node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+                node->AlignmentType   =  AlignmentType.Left;
+
+                LinkNodeAtEnd((AtkResNode*)node, hpNode);
+            }
+        }
+
+        public static unsafe void Disable()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_PartyList");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            DisableMitigationNodes(addon);
+            DisableShieldNodes(addon);
+        }
+
+        private static unsafe void DisableMitigationNodes(AtkUnitBase* addon)
+        {
+            foreach (uint i in Enumerable.Range(10, 8))
+            {
+                var memberNode = addon->GetComponentNodeById(i);
+
+                var node = FetchNode(MitigationNodeId, memberNode->Component);
+                if (node == null) continue;
+
+                UnlinkAndFreeTextNode((AtkTextNode*)node, memberNode);
+            }
+        }
+
+        private static unsafe void DisableShieldNodes(AtkUnitBase* addon)
+        {
+            foreach (uint i in Enumerable.Range(10, 8))
+            {
+                var memberNode = addon->GetComponentNodeById(i)->Component;
+                var hpNode     = FetchNode(12, memberNode)->GetAsAtkComponentNode();
+
+                var node = (AtkTextNode*)FetchNode(ShieldNodeId, hpNode->Component);
+                if (node == null) continue;
+
+                UnlinkAndFreeTextNode(node, hpNode);
+            }
+        }
+
+        public static unsafe void Update()
+        {
+            var addonPtr = DService.Gui.GetAddonByName("_PartyList");
+            if (addonPtr == IntPtr.Zero) return;
+            var addon = (AtkUnitBase*)addonPtr;
+
+            foreach (var memberStatus in MitigationService.FetchParty())
+            {
+                var memberIndex = FetchMemberIndex(memberStatus.Key) ?? 0;
+
+                UpdateMitigationNode(addon, memberIndex, memberStatus.Value);
+                UpdateShieldNodes(addon, memberIndex, memberStatus.Value);
+            }
+        }
+
+        private static unsafe void UpdateMitigationNode(AtkUnitBase* addon, uint memberIndex, float[] memberStatus)
+        {
+            var memberNode = addon->GetComponentNodeById(10 + memberIndex)->Component;
+            var plateNode  = FetchNode(14, memberNode);
+            var namePlate  = FetchNode(17, plateNode);
+
+            var node = (AtkTextNode*)FetchNode(MitigationNodeId, memberNode);
+            if (node == null) return;
+
+            if (memberStatus[0] == 0 && memberStatus[1] == 0)
+            {
+                node->ToggleVisibility(false);
+                return;
+            }
+
+            var desc = $"{Math.Max(memberStatus[0], memberStatus[1]):N0}%";
+
+            node->ToggleVisibility(namePlate->IsVisible());
+            node->SetText(desc);
+        }
+
+        private static unsafe void UpdateShieldNodes(AtkUnitBase* addon, uint memberIndex, float[] memberStatus)
+        {
+            var memberNode = addon->GetComponentNodeById(10 + memberIndex)->Component;
+            var hpNode     = FetchNode(12, memberNode)->GetAsAtkComponentNode()->Component;
+            var numNode    = FetchNode(2, hpNode);
+
+            var node = (AtkTextNode*)FetchNode(ShieldNodeId, hpNode);
+            if (node == null) return;
+
+            if (memberStatus[2] == 0)
+            {
+                node->ToggleVisibility(false);
+                return;
+            }
+
+            var desc = $"{memberStatus[2]:F0}";
+
+            node->ToggleVisibility(numNode->IsVisible());
+            node->SetText(desc);
+        }
+
+        private static unsafe AtkResNode* FetchNode(uint nodeId, AtkComponentBase* addon)
+        {
+            for (var i = 0; i < addon->UldManager.NodeListCount; i++)
+            {
+                var t = addon->UldManager.NodeList[i];
+                if (t->NodeId == nodeId)
+                    return t;
+            }
+
+            return null;
+        }
+
+        private static unsafe AtkResNode* FetchNode(uint nodeId, AtkResNode* addon)
+        {
+            for (var child = addon->ChildNode; child != null; child = child->NextSiblingNode)
+            {
+                if (child->NodeId == nodeId)
+                    return child;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region DamageMonitor
+
+    public static class DamageActionManager
+    {
+        // cache
+        public static Dictionary<uint, DamageAction> Actions       = [];
+        public static DamageAction                   CurrentAction = new() { ActionId = 0 };
+
+        #region Structs
+
+        public struct DamageAction
+        {
+            [JsonProperty("zone_id")]
+            public uint ZoneId { get; set; }
+
+            [JsonProperty("entity_id")]
+            public uint EntityId { get; set; }
+
+            [JsonProperty("action_id")]
+            public uint ActionId { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("range")]
+            public string Range { get; set; }
+
+            [JsonProperty("damage")]
+            public float Damage { get; set; }
+
+            [JsonProperty("duration")]
+            public float Duration { get; set; }
+        }
+
+        public enum EffectType : byte
+        {
+            Nothing                   = 0,
+            Miss                      = 1,
+            FullResist                = 2,
+            Damage                    = 3,
+            Heal                      = 4,
+            BlockedDamage             = 5,
+            ParriedDamage             = 6,
+            Invulnerable              = 7,
+            NoEffectText              = 8,
+            MpLoss                    = 10,
+            MpGain                    = 11,
+            TpLoss                    = 12,
+            TpGain                    = 13,
+            ApplyStatusEffectTarget   = 14,
+            ApplyStatusEffectSource   = 15,
+            RecoveredFromStatusEffect = 16,
+            LoseStatusEffectTarget    = 17,
+            LoseStatusEffectSource    = 18,
+            StatusNoEffect            = 20,
+            ThreatPosition            = 24,
+            EnmityAmountUp            = 25,
+            EnmityAmountDown          = 26,
+            StartActionCombo          = 27,
+            Knockback                 = 33,
+            Mount                     = 40,
+            FullResistStatus          = 55,
+            Vfx                       = 59,
+            Gauge                     = 60,
+            PartialInvulnerable       = 74,
+            Interrupt                 = 75,
+        }
+
+        public enum EffectDisplayType : byte
+        {
+            HideActionName = 0,
+            ShowActionName = 1,
+            ShowItemName   = 2,
+            MountName      = 13
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct EffectHeader
+        {
+            public uint AnimationTargetId;
+
+            public uint Unknown1;
+
+            public uint ActionId;
+
+            public uint GlobalEffectCounter;
+
+            public float AnimationLockTime;
+
+            public uint Unknown2;
+
+            public ushort HiddenAnimation;
+
+            public ushort Rotation;
+
+            public ushort ActionAnimationId;
+
+            public byte Variation;
+
+            public EffectDisplayType EffectDisplayType;
+
+            public byte Unknown3;
+
+            public byte EffectCount;
+
+            public ushort Unknown4;
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct Effect
+        {
+            public EffectType EffectType;
+            public byte       Param0;
+            public byte       Param1;
+            public byte       Param2;
+            public byte       Flags1;
+            public byte       Flags2;
+            public ushort     Value;
+        }
+
+        #endregion
+
+        #region Hooks
+
+        // start cast hook
+        private static readonly CompSig                  StartCastSig = new("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 89 BC 24 D0 00 00 00");
+        private static          Hook<StartCastDelegate>? StartCastHook;
+
+        // start cast delegate
+        private unsafe delegate nint StartCastDelegate(BattleChara* player, ActionType type, uint actionId, nint a4, float rotation, float a6);
+
+        // complete cast hook
+        private static readonly CompSig                     CompleteCastSig = new("E8 ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 45 33 C0 48 8D 0D");
+        private static          Hook<CompleteCastDelegate>? CompleteCastHook;
+
+        // complete cast delegate
+        private unsafe delegate nint CompleteCastDelegate(
+            BattleChara* player,   ActionType type,     uint  actionId,               uint spellId,            GameObjectId animationTargetId,
+            Vector3*     location, float      rotation, short lastUsedActionSequence, int  animationVariation, int          ballistaEntityId
+        );
+
+        // action effect hook
+        private static readonly CompSig                       ActionEffectSig = new("E8 ?? ?? ?? ?? 48 8B 8D F0 03 00 00");
+        private static          Hook<OnActionEffectDelegate>? ActionEffectHook;
+
+        // action effect delegate
+        private unsafe delegate void OnActionEffectDelegate(int sourceId, BattleChara* player, Vector3* location, EffectHeader* effectHeader, Effect* effectArray, ulong* effectTrail);
+
+        public static unsafe void Enable()
+        {
+            StartCastHook?.Dispose();
+            StartCastHook = StartCastSig.GetHook<StartCastDelegate>(OnStartCast);
+            StartCastHook.Enable();
+
+            CompleteCastHook?.Dispose();
+            CompleteCastHook = CompleteCastSig.GetHook<CompleteCastDelegate>(OnCompleteCast);
+            CompleteCastHook.Enable();
+
+            ActionEffectHook?.Dispose();
+            ActionEffectHook = ActionEffectSig.GetHook<OnActionEffectDelegate>(OnActionEffect);
+            ActionEffectHook.Enable();
+
+            // auto emit from pipe
+            ActionPipe = new();
+            Task.Run(ListenAction);
+        }
+
+        public static void Disable()
+        {
+            StartCastHook?.Dispose();
+            CompleteCastHook?.Dispose();
+            ActionEffectHook?.Dispose();
+
+            // auto emit from pipe
+            ActionPipe?.Cancel();
+        }
+
+        private static unsafe nint OnStartCast(BattleChara* player, ActionType type, uint actionId, nint a4, float rotation, float a6)
+        {
+            // auto emit from cache
+            if (CurrentAction.ActionId == 0)
+                FindAction(actionId);
+
+            return StartCastHook.Original(player, ActionType.Action, actionId, a4, rotation, a6);
+        }
+
+        private static unsafe nint OnCompleteCast(
+            BattleChara* player,   ActionType type,     uint  actionId,               uint spellId,            GameObjectId animationTargetId,
+            Vector3*     location, float      rotation, short lastUsedActionSequence, int  animationVariation, int          ballistaEntityId
+        )
+        {
+            // auto clear (duration = 0)
+            if (CurrentAction.ActionId == actionId && CurrentAction.Duration == 0)
+                ClearAction();
+
+            return CompleteCastHook.Original(player, type, actionId, spellId, animationTargetId, location, rotation, lastUsedActionSequence, animationVariation, ballistaEntityId);
+        }
+
+        private static unsafe void OnActionEffect(int sourceId, BattleChara* player, Vector3* location, EffectHeader* effectHeader, Effect* effectArray, ulong* effectTrail)
+        {
+            ActionEffectHook.Original(sourceId, player, location, effectHeader, effectArray, effectTrail);
+
+            try
+            {
+                for (var i = 0; i < effectHeader->EffectCount; i++)
+                {
+                    var targetId = (uint)(effectTrail[i] & uint.MaxValue);
+                    var actionId = effectHeader->EffectDisplayType switch
+                    {
+                        EffectDisplayType.MountName => 0xD_000_000 + effectHeader->ActionId,
+                        EffectDisplayType.ShowItemName => 0x2_000_000 + effectHeader->ActionId,
+                        _ => effectHeader->ActionAnimationId
+                    };
+
+                    for (var j = 0; j < 8; j++)
+                    {
+                        ref var effect = ref effectArray[i * 8 + j];
+                        if (effect.EffectType == 0) continue;
+
+                        // unzip damage [high8: Flag1, low16: Value]
+                        uint damage = effect.Value;
+                        if ((effect.Flags2 & 0x40) == 0x40)
+                            damage += (uint)effect.Flags1 << 16;
+                    }
+                }
+            }
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] OnActionEffect Hook Failed: {ex}"); }
+        }
+
+        #endregion
+
+        #region Action
+
+        private static void FindAction(uint actionId)
+        {
+            // match action from cache
+            if (!Actions.TryGetValue(actionId, out CurrentAction))
+                return;
+
+            // duration?
+            if (CurrentAction.Duration > 0)
+                Task.Run(async () => await Timer.Emit(ClearAction, (int)(CurrentAction.Duration * 1000)));
+        }
+
+        private static CancellationTokenSource? ActionPipe;
+
+        private static void ListenAction()
+        {
+            return;
+            while (!ActionPipe.IsCancellationRequested)
+            {
+                using var pipe = new NamedPipeServerStream("DR-ADMI", PipeDirection.In, 4);
+                pipe.WaitForConnection();
+
+                try
+                {
+                    using var reader = new StreamReader(pipe);
+                    var       json   = reader.ReadLine();
+                    if (string.IsNullOrEmpty(json)) continue;
+
+
+                    CurrentAction = JsonConvert.DeserializeObject<DamageAction>(json);
+                    if (CurrentAction.Duration > 0)
+                        Task.Run(async () => await Timer.Emit(ClearAction, (int)(CurrentAction.Duration * 1000)));
+                }
+                catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] Damage Action Pipe Listen Failed: {ex}"); }
+            }
+        }
+
+        private static void ClearAction()
+            => CurrentAction = new DamageAction() { ActionId = 0 };
+
+        #endregion
+
+        #region Funcs
+
+        public static float FetchLocalDamage()
+        {
+            if (CurrentAction.ActionId == 0) return 0;
+
+            var status = MitigationService.FetchLocal();
+            var mitigation = CurrentAction.Type switch
+            {
+                "Physical" => status[0],
+                "Magical" => status[1],
+                _ => 0
+            };
+            var shield = status[2];
+
+            return CurrentAction.Damage * (1 - (mitigation / 100)) - shield;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Timer
+
+    public static class Timer
+    {
+        private static CancellationTokenSource? CTS;
+
+        public static async Task Emit(Action onElapsed, int delay)
+        {
+            // cancel previous timer
+            CTS?.Cancel();
+            CTS?.Dispose();
+
+            // create a new timer
+            CTS = new CancellationTokenSource();
+            var token = CTS.Token;
+
+            try
+            {
+                await Task.Delay(delay, token);
+
+                // check if the token is not canceled
+                if (!token.IsCancellationRequested)
+                    onElapsed();
+            }
+            catch (TaskCanceledException) { }
         }
     }
 
     #endregion
 
+    #region Mitigation
+
+    public unsafe class MitigationManager(MitigationManager.Storage config)
+    {
+        // cache
+        private Dictionary<uint, Status> _statusDict = [];
+
+        // local player
+        public readonly Dictionary<Status, float> LocalActiveStatus = [];
+        public          float                     LocalShield => ((float)Control.GetLocalPlayer()->ShieldValue / 100 * Control.GetLocalPlayer()->Health);
+
+        // party member
+        public readonly Dictionary<uint, Dictionary<Status, float>> PartyActiveStatus = [];
+
+        public Dictionary<uint, float> PartyShield
+        {
+            get
+            {
+                var partyShield = new Dictionary<uint, float>();
+                var partyList   = DService.PartyList.OrderBy(member => FetchMemberIndex(member.ObjectId) ?? 0).ToList();
+
+                foreach (var member in partyList)
+                    if (DService.ObjectTable.SearchById(member.ObjectId) is ICharacter memberChara)
+                        partyShield[member.ObjectId] = ((float)memberChara.ShieldPercentage / 100 * memberChara.CurrentHp);
+
+                return partyShield;
+            }
+        }
+
+        // battle npc
+        public readonly Dictionary<Status, float> BattleNpcActiveStatus = [];
+
+        // config
+        public class Storage
+        {
+            public Status[] Statuses = [];
+        }
+
+        #region Structs
+
+        public struct StatusInfo
+        {
+            [JsonProperty("physical")]
+            public float Physical { get; private set; }
+
+            [JsonProperty("magical")]
+            public float Magical { get; private set; }
+        }
+
+        public struct Status : IEquatable<Status>
+        {
+            [JsonProperty("id")]
+            public uint Id { get; private set; }
+
+            [JsonProperty("name")]
+            public string Name { get; private set; }
+
+            [JsonProperty("mitigation")]
+            public StatusInfo Info { get; private set; }
+
+            [JsonProperty("on_member")]
+            public bool OnMember { get; private set; }
+
+            #region Equals
+
+            public bool Equals(Status other) => Id == other.Id;
+
+            public override bool Equals(object? obj) => obj is Status other && Equals(other);
+
+            public override int GetHashCode() => (int)Id;
+
+            public static bool operator ==(Status left, Status right) => left.Equals(right);
+
+            public static bool operator !=(Status left, Status right) => !left.Equals(right);
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Funcs
+
+        public void InitStatusMap()
+            => _statusDict = config.Statuses.ToDictionary(x => x.Id, x => x);
+
+        public void Update()
+        {
+            // clear cache
+            Clear();
+
+            // local player
+            if (DService.ClientState.LocalPlayer is not { } localPlayer) return;
+            // status
+            foreach (var status in localPlayer.StatusList)
+                if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+                    LocalActiveStatus.Add(mitigation, status.RemainingTime);
+
+            // party
+            var partyList = DService.PartyList.OrderBy(member => FetchMemberIndex(member.ObjectId) ?? 0).ToList();
+            foreach (var member in partyList)
+            {
+                var activateStatus = new Dictionary<Status, float>();
+                foreach (var status in member.Statuses)
+                    if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+                        activateStatus.Add(mitigation, status.RemainingTime);
+
+                PartyActiveStatus[member.ObjectId] = activateStatus;
+            }
+
+            // battle npc
+            var currentTarget = DService.Targets.Target;
+            if (currentTarget is IBattleNpc battleNpc)
+            {
+                var statusList = battleNpc.ToBCStruct()->StatusManager.Status;
+                foreach (var status in statusList)
+                    if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+                        BattleNpcActiveStatus.Add(mitigation, status.RemainingTime);
+            }
+        }
+
+        public void Clear()
+        {
+            LocalActiveStatus.Clear();
+            PartyActiveStatus.Clear();
+            BattleNpcActiveStatus.Clear();
+        }
+
+        public bool IsLocalEmpty()
+            => LocalActiveStatus.Count == 0 && LocalShield == 0 && BattleNpcActiveStatus.Count == 0;
+
+        public float[] FetchLocal()
+        {
+            var activeStatus = LocalActiveStatus.Concat(BattleNpcActiveStatus).ToDictionary(kv => kv.Key, kv => kv.Value);
+            return
+            [
+                Reduction(activeStatus.Keys.Select(x => x.Info.Physical)),
+                Reduction(activeStatus.Keys.Select(x => x.Info.Magical)),
+                LocalShield
+            ];
+        }
+
+        public Dictionary<uint, float[]> FetchParty()
+        {
+            if (DService.PartyList.Count == 0)
+                return new Dictionary<uint, float[]>() { { GameState.EntityID, FetchLocal() } };
+
+            var partyValues = new Dictionary<uint, float[]>();
+            foreach (var memberActiveStatus in PartyActiveStatus)
+            {
+                var activeStatus = memberActiveStatus.Value.Concat(BattleNpcActiveStatus).ToDictionary(kv => kv.Key, kv => kv.Value);
+                partyValues[memberActiveStatus.Key] =
+                [
+                    Reduction(activeStatus.Keys.Select(x => x.Info.Physical)),
+                    Reduction(activeStatus.Keys.Select(x => x.Info.Magical)),
+                    PartyShield[memberActiveStatus.Key]
+                ];
+            }
+
+            return partyValues;
+        }
+
+
+        public static float Reduction(IEnumerable<float> mitigations) =>
+            (1f - mitigations.Aggregate(1f, (acc, m) => acc * (1f - (m / 100f)))) * 100f;
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Utils
+
+    private static IPartyMember? FetchMember(uint id)
+        => DService.PartyList.FirstOrDefault(m => m.ObjectId == id);
+
+    private static unsafe uint? FetchMemberIndex(uint id)
+        => (uint)AgentHUD.Instance()->PartyMembers.ToArray()
+                                                  .Select((m, i) => (m, i))
+                                                  .FirstOrDefault(t => t.m.EntityId == id).i;
+
+    private static string NumToKilo(float num)
+        => num > 1000 ? $"{num / 1_000:N0}K" : $"{num:N0}";
+
+    #endregion
+
     #region Config
 
-    private class Config : ModuleConfiguration
+    private class ModuleStorage : ModuleConfiguration
     {
+        // mitigation
+        public readonly MitigationManager.Storage MitigationStorage = new();
+
+        // activate
         public bool OnlyInCombat = true;
-        
+
+        // ui
         public bool TransparentOverlay;
         public bool ResizeableOverlay = true;
-        public bool MoveableOverlay = true;
-
-        // remote cache
-        public string             LocalCacheVersion  = "0.0.0";
-        public MitigationStatus[] MitigationStatuses = [];
-    }
-
-    public struct MitigationDetail
-    {
-        [JsonProperty("physical")]
-        public float Physical { get; private set; }
-
-        [JsonProperty("magical")]
-        public float Magical { get; private set; }
-
-        [JsonProperty("special")]
-        public float Special { get; private set; }
-    }
-
-    public struct MitigationStatus : IEquatable<MitigationStatus>
-    {
-        [JsonProperty("id")]
-        public uint Id { get; private set; }
-
-        [JsonProperty("name")]
-        public string Name { get; private set; }
-
-        [JsonProperty("mitigation")]
-        public MitigationDetail Mitigation { get; private set; }
-
-        [JsonProperty("on_member")]
-        public bool OnMember { get; private set; }
-
-        public bool Equals(MitigationStatus other) => Id == other.Id;
-
-        public override bool Equals(object? obj) => obj is MitigationStatus other && Equals(other);
-
-        public override int GetHashCode() => (int)Id;
-
-        public static bool operator ==(MitigationStatus left, MitigationStatus right) => left.Equals(right);
-
-        public static bool operator !=(MitigationStatus left, MitigationStatus right) => !left.Equals(right);
+        public bool MoveableOverlay   = true;
     }
 
     #endregion

--- a/Combat/AutoDisplayMitigationInfo.cs
+++ b/Combat/AutoDisplayMitigationInfo.cs
@@ -61,7 +61,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         StatusBarManager.Enable();
         StatusBarManager.BarEntry.OnClick = () =>
         {
-            if (Overlay == null) return;
+            if (Overlay == null)
+                return;
             Overlay.IsOpen ^= true;
         };
 
@@ -164,20 +165,23 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
     public override unsafe void OverlayUI()
     {
-        if (Control.GetLocalPlayer() == null || MitigationService.IsLocalEmpty()) return;
+        if (Control.GetLocalPlayer() == null || MitigationService.IsLocalEmpty())
+            return;
 
         ImGuiHelpers.SeStringWrapped(StatusBarManager.BarEntry?.Text?.Encode() ?? []);
 
         ImGui.Separator();
 
         using var table = ImRaii.Table("StatusTable", 3);
-        if (!table) return;
+        if (!table)
+            return;
 
         ImGui.TableSetupColumn("Icon", ImGuiTableColumnFlags.WidthFixed, 24f * GlobalFontScale);
         ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 20);
         ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 20);
 
-        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon)) return;
+        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon))
+            return;
 
         // local status
         foreach (var status in MitigationService.LocalActiveStatus)
@@ -243,8 +247,10 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
     private static void DrawStatusRow(KeyValuePair<MitigationManager.Status, float> status)
     {
-        if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row)) return;
-        if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon)) return;
+        if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row))
+            return;
+        if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon))
+            return;
 
         ImGui.TableNextRow();
 
@@ -382,7 +388,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
             for (var i = 0; i < values.Length; i++)
             {
-                if (values[i] <= 0) continue;
+                if (values[i] <= 0)
+                    continue;
 
                 var icon = i switch
                 {
@@ -392,7 +399,9 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                     _ => BitmapFontIcon.None,
                 };
 
-                if (!firstBarItem) textBuilder.Append(" ");
+                if (!firstBarItem)
+                    textBuilder.Append(" ");
+
                 textBuilder.AddIcon(icon);
                 textBuilder.Append($"{values[i]:0}" + (i != 2 ? "%" : ""));
                 firstBarItem = false;
@@ -407,7 +416,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             // status
             foreach (var (status, _) in MitigationService.LocalActiveStatus)
             {
-                if (!firstTipItem) tipBuilder.Append("\n");
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
                 tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
                 tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
                 tipBuilder.Append($"{status.Info.Physical}% ");
@@ -419,7 +429,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             // shield
             if (MitigationService.LocalShield > 0)
             {
-                if (!firstTipItem) tipBuilder.Append("\n");
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
                 tipBuilder.AddIcon(BitmapFontIcon.Tank);
                 tipBuilder.Append($"{GetLoc("Shield")}: {MitigationService.LocalShield}");
                 firstTipItem = false;
@@ -428,7 +439,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             // battle npc
             foreach (var (status, _) in MitigationService.BattleNpcActiveStatus)
             {
-                if (!firstTipItem) tipBuilder.Append("\n");
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
                 tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
                 tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
                 tipBuilder.Append($"{status.Info.Physical}% ");
@@ -443,7 +455,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
         public static void Clear()
         {
-            if (BarEntry == null) return;
+            if (BarEntry == null)
+                return;
 
             BarEntry.Shown   = false;
             BarEntry.Tooltip = null;
@@ -473,7 +486,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Enable()
         {
             var addon = GetAddonByName("_TargetInfoCastBar");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             var castBar = addon->GetNodeById(2);
 
@@ -504,10 +518,12 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Disable()
         {
             var addon = GetAddonByName("_TargetInfoCastBar");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             var node = FetchNode(NodeId, addon);
-            if (node == null) return;
+            if (node == null)
+                return;
             UnlinkAndFreeTextNode((AtkTextNode*)node, addon);
         }
 
@@ -520,10 +536,12 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             }
 
             var addon = GetAddonByName("_TargetInfoCastBar");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             var node = (AtkTextNode*)FetchNode(NodeId, addon);
-            if (node == null) return;
+            if (node == null)
+                return;
 
             node->ToggleVisibility(true);
             node->SetText(DamageActionManager.FetchLocalDamage().ToString("N0"));
@@ -532,10 +550,12 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Clear()
         {
             var addon = GetAddonByName("_TargetInfoCastBar");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             var node = (AtkTextNode*)FetchNode(NodeId, addon);
-            if (node == null) return;
+            if (node == null)
+                return;
 
             node->ToggleVisibility(false);
         }
@@ -570,7 +590,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Enable()
         {
             var addon = GetAddonByName("_PartyList");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             EnableMitigationNodes(addon);
             EnableShieldNodes(addon);
@@ -644,7 +665,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Disable()
         {
             var addon = GetAddonByName("_PartyList");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             DisableMitigationNodes(addon);
             DisableShieldNodes(addon);
@@ -657,7 +679,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                 var memberNode = addon->GetComponentNodeById(i);
 
                 var node = FetchNode(MitigationNodeId, memberNode->Component);
-                if (node == null) continue;
+                if (node == null)
+                    continue;
 
                 UnlinkAndFreeTextNode((AtkTextNode*)node, memberNode);
             }
@@ -671,7 +694,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                 var hpNode     = FetchNode(12, memberNode)->GetAsAtkComponentNode();
 
                 var node = (AtkTextNode*)FetchNode(ShieldNodeId, hpNode->Component);
-                if (node == null) continue;
+                if (node == null)
+                    continue;
 
                 UnlinkAndFreeTextNode(node, hpNode);
             }
@@ -680,7 +704,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         public static unsafe void Update()
         {
             var addon = GetAddonByName("_PartyList");
-            if (addon == null) return;
+            if (addon == null)
+                return;
 
             foreach (var memberStatus in MitigationService.FetchParty())
             {
@@ -698,7 +723,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             var namePlate  = FetchNode(17, plateNode);
 
             var node = (AtkTextNode*)FetchNode(MitigationNodeId, memberNode);
-            if (node == null) return;
+            if (node == null)
+                return;
 
             if (memberStatus[0] == 0 && memberStatus[1] == 0)
             {
@@ -719,7 +745,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             var numNode    = FetchNode(2, hpNode);
 
             var node = (AtkTextNode*)FetchNode(ShieldNodeId, hpNode);
-            if (node == null) return;
+            if (node == null)
+                return;
 
             if (memberStatus[2] == 0)
             {
@@ -983,7 +1010,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                     for (var j = 0; j < 8; j++)
                     {
                         ref var effect = ref effectArray[i * 8 + j];
-                        if (effect.EffectType == 0) continue;
+                        if (effect.EffectType == 0)
+                            continue;
 
                         // unzip damage [high8: Flag1, low16: Value]
                         uint damage = effect.Value;
@@ -1024,7 +1052,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                 {
                     using var reader = new StreamReader(pipe);
                     var       json   = reader.ReadLine();
-                    if (string.IsNullOrEmpty(json)) continue;
+                    if (string.IsNullOrEmpty(json))
+                        continue;
 
 
                     CurrentAction = JsonConvert.DeserializeObject<DamageAction>(json);
@@ -1044,7 +1073,8 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
         public static float FetchLocalDamage()
         {
-            if (CurrentAction.ActionId == 0) return 0;
+            if (CurrentAction.ActionId == 0)
+                return 0;
 
             var status = MitigationService.FetchLocal();
             var mitigation = CurrentAction.Type switch
@@ -1098,7 +1128,7 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
     public unsafe class MitigationManager(MitigationManager.Storage config)
     {
         // cache
-        private Dictionary<uint, Status> _statusDict = [];
+        private Dictionary<uint, Status> statusDict = [];
 
         // local player
         public readonly Dictionary<Status, float> LocalActiveStatus = [];
@@ -1115,8 +1145,10 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                 var partyList   = DService.PartyList.OrderBy(member => FetchMemberIndex(member.ObjectId) ?? 0).ToList();
 
                 foreach (var member in partyList)
+                {
                     if (DService.ObjectTable.SearchById(member.ObjectId) is ICharacter memberChara)
                         partyShield[member.ObjectId] = ((float)memberChara.ShieldPercentage / 100 * memberChara.CurrentHp);
+                }
 
                 return partyShield;
             }
@@ -1176,7 +1208,7 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         #region Funcs
 
         public void InitStatusMap()
-            => _statusDict = config.Statuses.ToDictionary(x => x.Id, x => x);
+            => statusDict = config.Statuses.ToDictionary(x => x.Id, x => x);
 
         public void Update()
         {
@@ -1185,12 +1217,15 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 
             // local player
             var localPlayer = Control.GetLocalPlayer();
-            if (localPlayer == null) return;
+            if (localPlayer == null)
+                return;
 
             // status
             foreach (var status in localPlayer->StatusManager.Status)
-                if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+            {
+                if (statusDict.TryGetValue(status.StatusId, out var mitigation))
                     LocalActiveStatus.Add(mitigation, status.RemainingTime);
+            }
 
             // party
             var partyList = DService.PartyList.OrderBy(member => FetchMemberIndex(member.ObjectId) ?? 0).ToList();
@@ -1198,8 +1233,10 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             {
                 var activateStatus = new Dictionary<Status, float>();
                 foreach (var status in member.Statuses)
-                    if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+                {
+                    if (statusDict.TryGetValue(status.StatusId, out var mitigation))
                         activateStatus.Add(mitigation, status.RemainingTime);
+                }
 
                 PartyActiveStatus[member.ObjectId] = activateStatus;
             }
@@ -1210,8 +1247,10 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             {
                 var statusList = battleNpc.ToBCStruct()->StatusManager.Status;
                 foreach (var status in statusList)
-                    if (_statusDict.TryGetValue(status.StatusId, out var mitigation))
+                {
+                    if (statusDict.TryGetValue(status.StatusId, out var mitigation))
                         BattleNpcActiveStatus.Add(mitigation, status.RemainingTime);
+                }
             }
         }
 


### PR DESCRIPTION
**新增功能**

1. 在小队列表中直接显示每个成员的减伤和护盾信息
2. 部分副本的部分技能的预期伤害会直接显示在敌方读条旁 【热更新】

**重构代码** ~~又要开始炸了~~

1. 封装了多个类用来维护状态
2. 使用后端缓存代替前端缓存