### PR TITLE
【减伤显示 修复】【治疗优化 汉化错误处理】【新模块 延续性状态技能提示】

### DIFF
--- a/Action/HealerHelper.cs
+++ b/Action/HealerHelper.cs
@@ -58,19 +58,18 @@ public class HealerHelper : DailyModuleBase
     {
         moduleConfig = LoadConfig<ModuleStorage>() ?? new ModuleStorage();
 
-        // fetch remote hotfix
-        Task.Run(async () =>
-        {
-            await RemoteRepoManager.FetchPlayCardOrder();
-            await RemoteRepoManager.FetchHealActions();
-            await RemoteRepoManager.FetchTerritoryMap();
-        });
-        SaveConfig(moduleConfig);
-
         // managers
         easyHealService     = new EasyHealManager(moduleConfig.EasyHealStorage);
         autoPlayCardService = new AutoPlayCardManager(moduleConfig.AutoPlayCardStorage);
         fflogsService       = new FFLogsManager(moduleConfig.FFLogsStorage);
+
+        // fetch remote hotfix
+        Task.WhenAll(
+            RemoteRepoManager.FetchPlayCardOrder(),
+            RemoteRepoManager.FetchHealActions(),
+            RemoteRepoManager.FetchTerritoryMap()
+        ).Wait();
+        SaveConfig(moduleConfig);
 
         // register hooks
         UseActionManager.RegPreUseActionLocation(OnPreUseAction);

--- a/Combat/AutoDisplayMitigationInfo.cs
+++ b/Combat/AutoDisplayMitigationInfo.cs
@@ -22,6 +22,7 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
 {
     #region Core
 
+    // info
     public override ModuleInfo Info { get; } = new()
     {
         Title       = GetLoc("AutoDisplayMitigationInfoTitle"),
@@ -30,90 +31,112 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         Author      = ["HaKu"]
     };
 
-    // icon asset
-    private static readonly byte[] DamagePhysicalStr;
-    private static readonly byte[] DamageMagicalStr;
+    // storage
+    private static ModuleStorage? moduleConfig;
 
-    // config & overlay
-    private static Config        ModuleConfig = null!;
-    private static IDtrBarEntry? BarEntry;
-
-    // cache variables
-    private static Dictionary<uint, MitigationStatus>  MitigationStatusMap  = [];
-    private static Dictionary<MitigationStatus, float> LastMitigationStatus = [];
+    // asset
+    private static readonly byte[] damagePhysicalStr;
+    private static readonly byte[] damageMagicalStr;
 
     static AutoDisplayMitigationInfo()
     {
-        DamagePhysicalStr = new SeString(new IconPayload(BitmapFontIcon.DamagePhysical)).Encode();
-        DamageMagicalStr  = new SeString(new IconPayload(BitmapFontIcon.DamageMagical)).Encode();
+        damagePhysicalStr = new SeString(new IconPayload(BitmapFontIcon.DamagePhysical)).Encode();
+        damageMagicalStr  = new SeString(new IconPayload(BitmapFontIcon.DamageMagical)).Encode();
     }
+
+    // managers
+    public static MitigationManager MitigationService;
 
     public override void Init()
     {
-        ModuleConfig = LoadConfig<Config>() ?? new();
+        moduleConfig = LoadConfig<ModuleStorage>() ?? new ModuleStorage();
+
+        // enable cast hook
+        DamageActionManager.Enable();
+
+        // enable mitigation hook
+        MitigationService = new MitigationManager(moduleConfig.MitigationStorage);
 
         // overlay
-        Overlay            ??= new(this);
-        Overlay.WindowName =   GetLoc("AutoDisplayMitigationInfoTitle");
-        Overlay.Flags      &=  ~ImGuiWindowFlags.NoTitleBar;
-        Overlay.Flags      &=  ~ImGuiWindowFlags.AlwaysAutoResize;
-        
-        if (ModuleConfig.TransparentOverlay)
-        {
-            Overlay.Flags |= ImGuiWindowFlags.NoBackground;
-            Overlay.Flags |= ImGuiWindowFlags.NoTitleBar;
-        }
-        else
-        {
-            Overlay.Flags &= ~ImGuiWindowFlags.NoBackground;
-            Overlay.Flags &= ~ImGuiWindowFlags.NoTitleBar;
-        }
+        SetOverlay();
 
-        if (ModuleConfig.ResizeableOverlay)
-            Overlay.Flags &= ~ImGuiWindowFlags.NoResize;
-        else
-            Overlay.Flags |= ImGuiWindowFlags.NoResize;
-
-        if (!ModuleConfig.MoveableOverlay)
-        {
-            Overlay.Flags |= ImGuiWindowFlags.NoMove;
-            Overlay.Flags |= ImGuiWindowFlags.NoInputs;
-        }
-        else
-        {
-            Overlay.Flags &= ~ImGuiWindowFlags.NoMove;
-            Overlay.Flags &= ~ImGuiWindowFlags.NoInputs;
-        }
-        
         // status bar
-        BarEntry ??= DService.DtrBar.Get("DailyRoutines-AutoDisplayMitigationInfo");
-        BarEntry.OnClick = () =>
+        StatusBarManager.Enable();
+        StatusBarManager.BarEntry.OnClick = () =>
         {
-            if (Overlay == null) return;
+            if (Overlay == null)
+                return;
             Overlay.IsOpen ^= true;
         };
 
-        // fetch remote resources
-        DService.Framework.RunOnTick(async () => await FetchRemoteVersion());
+        // fetch remote resource
+        Task.Run(async () =>
+        {
+            await RemoteRepoManager.FetchMitigationStatuses();
+            await RemoteRepoManager.FetchDamageActions();
+        });
+        SaveConfig(moduleConfig);
 
-        // life cycle hooks
-        FrameworkManager.Register(OnFrameworkUpdate, throttleMS: 500);
+        // zone hook
+        DService.ClientState.TerritoryChanged += OnZoneChanged;
+
+        // party list
+        DService.AddonLifecycle.RegisterListener(AddonEvent.PostSetup, "_PartyList", PartyListManager.OnPartyListSetup);
+        DService.AddonLifecycle.RegisterListener(AddonEvent.PreFinalize, "_PartyList", PartyListManager.OnPartyListFinalize);
+
+        // target cast bar
+        // DService.AddonLifecycle.RegisterListener(AddonEvent.PostDraw, "_TargetInfoCastBar", CastBarManager.Update);
+        // DService.AddonLifecycle.RegisterListener(AddonEvent.PreFinalize, "_TargetInfoCastBar", CastBarManager.Disable);
+
+        // refresh mitigation status
+        FrameworkManager.Register(OnFrameworkUpdate);
+        FrameworkManager.Register(OnFrameworkUpdateInterval, throttleMS: 500);
+
+        UnsafeInit();
     }
 
-    #endregion
+    private static unsafe void UnsafeInit()
+    {
+        // party list
+        if (PartyListManager.PartyList is not null)
+            PartyListManager.Enable(PartyListManager.PartyList);
+    }
 
-    #region UI
+    public override void Uninit()
+    {
+        // zone hook
+        DService.ClientState.TerritoryChanged -= OnZoneChanged;
+
+        // party list refresh
+        DService.AddonLifecycle.UnregisterListener(AddonEvent.PostDraw, PartyListManager.OnPartyListSetup);
+        DService.AddonLifecycle.UnregisterListener(AddonEvent.PreFinalize, PartyListManager.OnPartyListFinalize);
+
+        // target cast bar refresh
+        // DService.AddonLifecycle.UnregisterListener(AddonEvent.PostDraw, CastBarManager.Update);
+
+        // refresh mitigation status
+        FrameworkManager.Unregister(OnFrameworkUpdate);
+        FrameworkManager.Unregister(OnFrameworkUpdateInterval);
+
+        // status bar
+        StatusBarManager.Disable();
+
+        // disable cast hook
+        DamageActionManager.Disable();
+
+        base.Uninit();
+    }
 
     public override void ConfigUI()
     {
-        if (ImGui.Checkbox(GetLoc("OnlyInCombat"), ref ModuleConfig.OnlyInCombat))
-            SaveConfig(ModuleConfig);
+        if (ImGui.Checkbox(GetLoc("OnlyInCombat"), ref moduleConfig.OnlyInCombat))
+            SaveConfig(moduleConfig);
 
-        if (ImGui.Checkbox(GetLoc("TransparentOverlay"), ref ModuleConfig.TransparentOverlay))
+        if (ImGui.Checkbox(GetLoc("TransparentOverlay"), ref moduleConfig.TransparentOverlay))
         {
-            SaveConfig(ModuleConfig);
+            SaveConfig(moduleConfig);
 
-            if (ModuleConfig.TransparentOverlay)
+            if (moduleConfig.TransparentOverlay)
             {
                 Overlay.Flags |= ImGuiWindowFlags.NoBackground;
                 Overlay.Flags |= ImGuiWindowFlags.NoTitleBar;
@@ -124,22 +147,22 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
                 Overlay.Flags &= ~ImGuiWindowFlags.NoTitleBar;
             }
         }
-        
-        if (ImGui.Checkbox(GetLoc("ResizeableOverlay"), ref ModuleConfig.ResizeableOverlay))
-        {
-            SaveConfig(ModuleConfig);
 
-            if (ModuleConfig.ResizeableOverlay)
+        if (ImGui.Checkbox(GetLoc("ResizeableOverlay"), ref moduleConfig.ResizeableOverlay))
+        {
+            SaveConfig(moduleConfig);
+
+            if (moduleConfig.ResizeableOverlay)
                 Overlay.Flags &= ~ImGuiWindowFlags.NoResize;
             else
                 Overlay.Flags |= ImGuiWindowFlags.NoResize;
         }
-        
-        if (ImGui.Checkbox(GetLoc("MoveableOverlay"), ref ModuleConfig.MoveableOverlay))
-        {
-            SaveConfig(ModuleConfig);
 
-            if (!ModuleConfig.MoveableOverlay)
+        if (ImGui.Checkbox(GetLoc("MoveableOverlay"), ref moduleConfig.MoveableOverlay))
+        {
+            SaveConfig(moduleConfig);
+
+            if (!moduleConfig.MoveableOverlay)
             {
                 Overlay.Flags |= ImGuiWindowFlags.NoMove;
                 Overlay.Flags |= ImGuiWindowFlags.NoInputs;
@@ -152,59 +175,42 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
         }
     }
 
+    #endregion
+
+    #region Overlay
+
     public override unsafe void OverlayUI()
     {
-        var localPlayer = Control.GetLocalPlayer();
-        if (localPlayer == null) return;
-        
-        if (LastMitigationStatus.Count == 0 && localPlayer->ShieldValue == 0) return;
+        if (Control.GetLocalPlayer() == null || MitigationService.IsLocalEmpty())
+            return;
 
-        ImGuiHelpers.SeStringWrapped(BarEntry?.Text?.Encode() ?? []);
+        ImGuiHelpers.SeStringWrapped(StatusBarManager.BarEntry?.Text?.Encode() ?? []);
 
         ImGui.Separator();
 
         using var table = ImRaii.Table("StatusTable", 3);
+        if (!table)
+            return;
 
-        if (!table) return;
+        ImGui.TableSetupColumn("Icon", ImGuiTableColumnFlags.WidthFixed, 24f * GlobalFontScale);
+        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 20);
+        ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 20);
 
-        ImGui.TableSetupColumn("图标", ImGuiTableColumnFlags.WidthFixed,   24f * GlobalFontScale);
-        ImGui.TableSetupColumn("名字", ImGuiTableColumnFlags.WidthStretch, 20);
-        ImGui.TableSetupColumn("数字", ImGuiTableColumnFlags.WidthStretch, 20);
+        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon))
+            return;
 
-        if (!DService.Texture.TryGetFromGameIcon(new(210405), out var barrierIcon)) return;
+        // local status
+        foreach (var status in MitigationService.LocalActiveStatus)
+            DrawStatusRow(status);
 
-        foreach (var status in LastMitigationStatus)
+        // battle npc status
+        foreach (var status in MitigationService.BattleNpcActiveStatus)
+            DrawStatusRow(status);
+
+        // local shield
+        if (MitigationService.LocalShield > 0)
         {
-            if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row)) continue;
-            if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon)) continue;
-
-            ImGui.TableNextRow();
-
-            ImGui.TableNextColumn();
-            ImGui.Image(icon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
-
-            ImGui.TableNextColumn();
-            ImGui.AlignTextToFramePadding();
-            ImGui.Text($"{row.Name} ({status.Value:F1}s)");
-            ImGuiOm.TooltipHover($"{status.Key.Id}");
-
-            ImGui.TableNextColumn();
-            ImGuiHelpers.SeStringWrapped(DamagePhysicalStr);
-
-            ImGui.SameLine();
-            ImGui.Text($"{status.Key.Mitigation.Physical}% ");
-
-            ImGui.SameLine();
-            ImGuiHelpers.SeStringWrapped(DamageMagicalStr);
-
-            ImGui.SameLine();
-            ImGui.Text($"{status.Key.Mitigation.Magical}% ");
-        }
-
-        var shieldValue = localPlayer->ShieldValue;
-        if (shieldValue > 0)
-        {
-            if (LastMitigationStatus.Count > 0)
+            if (!MitigationService.IsLocalEmpty())
                 ImGui.TableNextRow();
 
             ImGui.TableNextRow();
@@ -216,271 +222,1141 @@ public class AutoDisplayMitigationInfo : DailyModuleBase
             ImGui.Text($"{GetLoc("Shield")}");
 
             ImGui.TableNextColumn();
-            var shieldPercentage = (double)shieldValue / 100;
-            ImGui.Text($"{shieldValue}%% ({localPlayer->Health * shieldPercentage:F0})");
+            ImGui.Text($"{MitigationService.LocalShield}");
         }
+    }
+
+    private void SetOverlay()
+    {
+        Overlay            ??= new(this);
+        Overlay.WindowName =   GetLoc("AutoDisplayMitigationInfoTitle");
+        Overlay.Flags      &=  ~ImGuiWindowFlags.NoTitleBar;
+        Overlay.Flags      &=  ~ImGuiWindowFlags.AlwaysAutoResize;
+
+        if (moduleConfig.TransparentOverlay)
+        {
+            Overlay.Flags |= ImGuiWindowFlags.NoBackground;
+            Overlay.Flags |= ImGuiWindowFlags.NoTitleBar;
+        }
+        else
+        {
+            Overlay.Flags &= ~ImGuiWindowFlags.NoBackground;
+            Overlay.Flags &= ~ImGuiWindowFlags.NoTitleBar;
+        }
+
+        if (moduleConfig.ResizeableOverlay)
+            Overlay.Flags &= ~ImGuiWindowFlags.NoResize;
+        else
+            Overlay.Flags |= ImGuiWindowFlags.NoResize;
+
+        if (!moduleConfig.MoveableOverlay)
+        {
+            Overlay.Flags |= ImGuiWindowFlags.NoMove;
+            Overlay.Flags |= ImGuiWindowFlags.NoInputs;
+        }
+        else
+        {
+            Overlay.Flags &= ~ImGuiWindowFlags.NoMove;
+            Overlay.Flags &= ~ImGuiWindowFlags.NoInputs;
+        }
+    }
+
+    private static void DrawStatusRow(KeyValuePair<MitigationManager.Status, float> status)
+    {
+        if (!LuminaGetter.TryGetRow<Status>(status.Key.Id, out var row))
+            return;
+        if (!DService.Texture.TryGetFromGameIcon(new(row.Icon), out var icon))
+            return;
+
+        ImGui.TableNextRow();
+
+        ImGui.TableNextColumn();
+        ImGui.Image(icon.GetWrapOrEmpty().ImGuiHandle, ScaledVector2(24f));
+
+        ImGui.TableNextColumn();
+        ImGui.AlignTextToFramePadding();
+        ImGui.Text($"{row.Name} ({status.Value:F1}s)");
+        ImGuiOm.TooltipHover($"{status.Key.Id}");
+
+        ImGui.TableNextColumn();
+        ImGuiHelpers.SeStringWrapped(damagePhysicalStr);
+
+        ImGui.SameLine();
+        ImGui.Text($"{status.Key.Info.Physical}% ");
+
+        ImGui.SameLine();
+        ImGuiHelpers.SeStringWrapped(damageMagicalStr);
+
+        ImGui.SameLine();
+        ImGui.Text($"{status.Key.Info.Magical}% ");
     }
 
     #endregion
 
-    public override void Uninit()
-    {
-        FrameworkManager.Unregister(OnFrameworkUpdate);
-
-        BarEntry?.Remove();
-        BarEntry = null;
-
-        base.Uninit();
-    }
 
     #region Hooks
 
     public static unsafe void OnFrameworkUpdate(IFramework _)
     {
-        if (DService.ClientState.IsPvP || (ModuleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat]))
-        {
-            ClearAndCloseBarEntry();
+        var combatInactive = moduleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat];
+        if (DService.ClientState.IsPvP || combatInactive || Control.GetLocalPlayer() is null)
             return;
-        }
 
-        if (DService.ClientState.LocalPlayer is not { } localPlayer)
-        {
-            ClearAndCloseBarEntry();
-            return;
-        }
-
-        Dictionary<MitigationStatus, float> lastMitigationStatus = [];
-
-        var localPlayerStatus = localPlayer.StatusList;
-        foreach (var status in localPlayerStatus)
-        {
-            if (MitigationStatusMap.TryGetValue(status.StatusId, out var mitigation))
-                lastMitigationStatus.Add(mitigation, status.RemainingTime);
-        }
-
-        var currentTarget = DService.Targets.Target;
-        if (currentTarget is IBattleNpc battleNpc)
-        {
-            var statusList = battleNpc.ToBCStruct()->StatusManager.Status;
-            foreach (var status in statusList)
-            {
-                if (MitigationStatusMap.TryGetValue(status.StatusId, out var mitigation))
-                    lastMitigationStatus.Add(mitigation, status.RemainingTime);
-            }
-        }
-
-        LastMitigationStatus = lastMitigationStatus.ToDictionary(x => x.Key, x => x.Value);
-        if (LastMitigationStatus.Count == 0 && localPlayer.ShieldPercentage == 0)
-        {
-            ClearAndCloseBarEntry();
-            return;
-        }
-
-        RefreshBarEntry(LastMitigationStatus);
+        // update party list
+        PartyListManager.Update();
     }
 
-    #endregion
-
-    #region StatusBar
-
-    private static unsafe void RefreshBarEntry(Dictionary<MitigationStatus, float> statuses)
+    public static unsafe void OnFrameworkUpdateInterval(IFramework _)
     {
-        if (BarEntry == null) return;
-
-        var localPlayer = Control.GetLocalPlayer();
-        if (localPlayer == null) return;
-
-        var textBuildr = new SeStringBuilder();
-        var values = new[]
+        var combatInactive = moduleConfig.OnlyInCombat && !DService.Condition[ConditionFlag.InCombat];
+        if (DService.ClientState.IsPvP || combatInactive || Control.GetLocalPlayer() is null)
         {
-            MitigationReduction(statuses.Keys.Select(x => x.Mitigation.Physical)),
-            MitigationReduction(statuses.Keys.Select(x => x.Mitigation.Magical)),
-            localPlayer->Character.ShieldValue,
-        };
-
-        for (var i = 0; i < values.Length; i++)
-        {
-            if (values[i] <= 0) continue;
-
-            var icon = i switch
-            {
-                0 => BitmapFontIcon.DamagePhysical,
-                1 => BitmapFontIcon.DamageMagical,
-                2 => BitmapFontIcon.Tank,
-                _ => BitmapFontIcon.None,
-            };
-
-            if (i != 0) 
-                textBuildr.Append(" ");
-            textBuildr.AddIcon(icon);
-            textBuildr.Append($"{values[i]:0.0}%");
+            StatusBarManager.Clear();
+            return;
         }
 
-        textBuildr.Append($" ({statuses.Count})");
-        BarEntry.Text = textBuildr.Build();
-
-        var tooltipBuilder = new SeStringBuilder();
-        foreach (var (status, _) in LastMitigationStatus)
-        {
-            tooltipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)} ({status.Id}):");
-            tooltipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
-            tooltipBuilder.Append($"{status.Mitigation.Physical}% ");
-            tooltipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
-            tooltipBuilder.Append($"{status.Mitigation.Magical}% ");
-            tooltipBuilder.Append("\n");
-        }
-
-        var shieldPercentage = (double)localPlayer->ShieldValue / 100;
-        if (localPlayer->ShieldValue > 0)
-        {
-            if (statuses.Count > 0)
-                tooltipBuilder.Append("\n");
-
-            tooltipBuilder.AddIcon(BitmapFontIcon.Tank);
-            tooltipBuilder.Append($"{GetLoc("Shield")}: {values[2]}% ({localPlayer->Health * shieldPercentage:F0})");
-        }
-
-        var built = tooltipBuilder.Build();
-        // remove last \n when no shield
-        if (localPlayer->ShieldValue == 0)
-            built.Payloads.RemoveAt(built.Payloads.Count - 1);
-
-        BarEntry.Tooltip = tooltipBuilder.Build();
-
-        BarEntry.Shown = true;
+        // update status
+        MitigationService.Update();
+        StatusBarManager.Update();
     }
 
-    private static void ClearAndCloseBarEntry()
-    {
-        if (BarEntry == null) return;
-
-        BarEntry.Shown   = false;
-        BarEntry.Tooltip = null;
-        BarEntry.Text    = null;
-    }
-
-    #endregion
-
-    #region Func
-
-    private static float MitigationReduction(IEnumerable<float> mitigations) =>
-        (1f - mitigations.Aggregate(1f, (acc, m) => acc * (1f - (m / 100f)))) * 100f;
-
-    private static void UpdateMitigationStatusMap()
-        => MitigationStatusMap = ModuleConfig.MitigationStatuses.ToDictionary(s => s.Id);
+    private static void OnZoneChanged(ushort zoneId)
+        => RemoteRepoManager.FetchDamageActions(zoneId);
 
     #endregion
 
     #region RemoteCache
 
-    // cache related client setting
-    private const string SuCache = "https://dr-cache.sumemo.dev";
-
-    private async Task FetchRemoteVersion()
+    public static class RemoteRepoManager
     {
-        // fetch remote data
-        try
-        {
-            var json = await HttpClientHelper.Get().GetStringAsync($"{SuCache}/version");
-            var resp = JsonConvert.DeserializeAnonymousType(json, new { version = "" });
-            if (resp == null || string.IsNullOrWhiteSpace(resp.version))
-                Error($"Deserialize Remote Version Failed: {json}");
-            else
-            {
-                // fetch remote data
-                var remoteCacheVersion = resp.version;
-                if (new Version(ModuleConfig.LocalCacheVersion) < new Version(remoteCacheVersion))
-                {
-                    // update config
-                    ModuleConfig.LocalCacheVersion = resp.version;
-                    SaveConfig(ModuleConfig);
+        // const
+        private const string Uri = "https://dr-cache.sumemo.dev";
 
-                    // update out-date cache
-                    await FetchMitigationStatuses();
+        public static async Task FetchMitigationStatuses()
+        {
+            try
+            {
+                var json = await HttpClientHelper.Get().GetStringAsync($"{Uri}/mitigation");
+                var resp = JsonConvert.DeserializeObject<MitigationManager.Status[]>(json);
+                if (resp == null)
+                    Error($"[AutoDisplayMitigationInfo] 远程减伤文件解析失败: {json}");
+                else
+                {
+                    moduleConfig.MitigationStorage.Statuses = resp;
+                    MitigationService.InitStatusMap();
+                }
+            }
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] 远程减伤文件获取失败: {ex}"); }
+        }
+
+        // TODO: separate by zone
+        private static DamageActionManager.DamageAction[] actions = [];
+
+        public static async Task FetchDamageActions()
+        {
+            try
+            {
+                var json = await HttpClientHelper.Get().GetStringAsync($"{Uri}/damage");
+                var resp = JsonConvert.DeserializeObject<DamageActionManager.DamageAction[]>(json);
+                if (resp == null)
+                    Error($"[AutoDisplayMitigationInfo] 远程技能伤害文件解析失败: {json}");
+                else
+                    actions = resp;
+            }
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] 远程技能伤害文件获取失败: {ex}"); }
+        }
+
+        public static void FetchDamageActions(uint zoneId)
+            => DamageActionManager.Actions = actions.Where(x => x.ZoneId == zoneId).ToDictionary(x => x.ActionId, x => x);
+    }
+
+    #endregion
+
+
+    #region StatusBar
+
+    public static class StatusBarManager
+    {
+        // cache
+        public static IDtrBarEntry? BarEntry;
+
+        #region Funcs
+
+        public static void Enable()
+            => BarEntry ??= DService.DtrBar.Get("DailyRoutines-AutoDisplayMitigationInfo");
+
+        public static void Update()
+        {
+            if (BarEntry == null || MitigationService.IsLocalEmpty())
+            {
+                Clear();
+                return;
+            }
+
+            // summary
+            var textBuilder  = new SeStringBuilder();
+            var values       = MitigationService.FetchLocal();
+            var firstBarItem = true;
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                if (values[i] <= 0)
+                    continue;
+
+                var icon = i switch
+                {
+                    0 => BitmapFontIcon.DamagePhysical,
+                    1 => BitmapFontIcon.DamageMagical,
+                    2 => BitmapFontIcon.Tank,
+                    _ => BitmapFontIcon.None,
+                };
+
+                if (!firstBarItem)
+                    textBuilder.Append(" ");
+
+                textBuilder.AddIcon(icon);
+                textBuilder.Append($"{values[i]:0}" + (i != 2 ? "%" : ""));
+                firstBarItem = false;
+            }
+
+            BarEntry.Text = textBuilder.Build();
+
+            // detail
+            var tipBuilder   = new SeStringBuilder();
+            var firstTipItem = true;
+
+            // status
+            foreach (var (status, _) in MitigationService.LocalActiveStatus)
+            {
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
+                tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
+                tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
+                tipBuilder.Append($"{status.Info.Physical}% ");
+                tipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
+                tipBuilder.Append($"{status.Info.Magical}% ");
+                firstTipItem = false;
+            }
+
+            // shield
+            if (MitigationService.LocalShield > 0)
+            {
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
+                tipBuilder.AddIcon(BitmapFontIcon.Tank);
+                tipBuilder.Append($"{GetLoc("Shield")}: {MitigationService.LocalShield}");
+                firstTipItem = false;
+            }
+
+            // battle npc
+            foreach (var (status, _) in MitigationService.BattleNpcActiveStatus)
+            {
+                if (!firstTipItem)
+                    tipBuilder.Append("\n");
+                tipBuilder.Append($"{LuminaWrapper.GetStatusName(status.Id)}:");
+                tipBuilder.AddIcon(BitmapFontIcon.DamagePhysical);
+                tipBuilder.Append($"{status.Info.Physical}% ");
+                tipBuilder.AddIcon(BitmapFontIcon.DamageMagical);
+                tipBuilder.Append($"{status.Info.Magical}% ");
+                firstTipItem = false;
+            }
+
+            BarEntry.Tooltip = tipBuilder.Build();
+            BarEntry.Shown   = true;
+        }
+
+        public static void Clear()
+        {
+            if (BarEntry == null)
+                return;
+
+            BarEntry.Shown   = false;
+            BarEntry.Tooltip = null;
+            BarEntry.Text    = null;
+        }
+
+        public static void Disable()
+        {
+            BarEntry?.Remove();
+            BarEntry = null;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region CastBar
+
+    public static class CastBarManager
+    {
+        // const
+        private const uint NodeId = 25;
+
+        // params
+        private static bool hasBuilt;
+
+        #region Funcs
+
+        public static unsafe void Enable()
+        {
+            var addon = GetAddonByName("_TargetInfoCastBar");
+            if (addon == null)
+                return;
+
+            var castBar = addon->GetNodeById(2);
+            if (castBar == null)
+                return;
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null && !TryMakeTextNode(NodeId, out node))
+                return;
+
+            node->FontSize = 10;
+            node->AtkResNode.SetWidth(200);
+            node->AtkResNode.SetHeight(castBar->GetHeight());
+            node->ToggleVisibility(false);
+            node->SetPositionShort(
+                (short)(castBar->GetXShort() + castBar->GetWidth()),
+                castBar->GetYShort()
+            );
+            node->DrawFlags       |= 1;
+            node->TextFlags       =  8;
+            node->TextFlags2      =  0;
+            node->FontType        =  FontType.MiedingerMed;
+            node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+            node->EdgeColor       =  new ByteColor { R = 255, G = 0, B   = 162, A = 157 };
+            node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+            node->AlignmentType   =  AlignmentType.BottomLeft;
+
+            LinkNodeAtEnd((AtkResNode*)node, addon);
+            hasBuilt = true;
+        }
+
+        public static unsafe void Disable(AddonEvent type, AddonArgs args)
+        {
+            var addon = GetAddonByName("_TargetInfoCastBar");
+            if (addon == null)
+                return;
+
+            var node = FetchNode(NodeId, addon);
+            if (node == null)
+                return;
+
+            UnlinkAndFreeTextNode((AtkTextNode*)node, addon);
+            hasBuilt = false;
+        }
+
+        public static unsafe void Update(AddonEvent type, AddonArgs args)
+        {
+            if (!hasBuilt)
+                Enable();
+
+            if (DamageActionManager.CurrentAction.ActionId == 0 || !IsScreenReady())
+            {
+                Clear();
+                return;
+            }
+
+            var addon = (AtkUnitBase*)args.Addon;
+            if (addon == null)
+                return;
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null)
+                return;
+
+            node->ToggleVisibility(true);
+            node->SetText(DamageActionManager.FetchLocalDamage().ToString("N0"));
+        }
+
+        public static unsafe void Clear()
+        {
+            var addon = GetAddonByName("_TargetInfoCastBar");
+            if (addon == null)
+                return;
+
+            var node = (AtkTextNode*)FetchNode(NodeId, addon);
+            if (node == null)
+                return;
+
+            node->ToggleVisibility(false);
+        }
+
+        private static unsafe AtkResNode* FetchNode(uint nodeId, AtkUnitBase* addon)
+        {
+            for (var i = 0; i < addon->UldManager.NodeListCount; i++)
+            {
+                var t = addon->UldManager.NodeList[i];
+                if (t->NodeId == nodeId)
+                    return t;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region PartyList
+
+    public static unsafe class PartyListManager
+    {
+        // const
+        private const uint MitigationNodeId = 100025;
+        private const uint ShieldNodeId     = 200025;
+
+        // params
+        private static bool            hasBuilt;
+        public static  AddonPartyList* PartyList => (AddonPartyList*)GetAddonByName("_PartyList");
+
+        // nodes
+        private static readonly nint[] mitigationNodes = new nint[8];
+        private static readonly nint[] shieldNodes     = new nint[8];
+
+        #region Funcs
+
+        public static void OnPartyListSetup(AddonEvent type, AddonArgs args)
+            => Enable((AddonPartyList*)args.Addon);
+
+        public static void Enable(AddonPartyList* addonPartyList)
+        {
+            DService.Framework.RunOnFrameworkThread(() =>
+            {
+                if (hasBuilt)
+                    return;
+
+                EnableMitigationNodes(addonPartyList);
+                EnableShieldNodes(addonPartyList);
+
+                hasBuilt = true;
+            });
+        }
+
+        private static void EnableMitigationNodes(AddonPartyList* addonPartyList)
+        {
+            foreach (var index in Enumerable.Range(0, 8))
+            {
+                ref var partyMember   = ref addonPartyList->PartyMembers[index];
+                ref var nameContainer = ref partyMember.NameAndBarsContainer;
+
+                if (!TryMakeTextNode(MitigationNodeId, out var node))
+                    continue;
+                mitigationNodes[index] = (nint)node;
+
+                node->FontSize = 10;
+                node->AtkResNode.SetWidth(nameContainer->GetWidth());
+                node->AtkResNode.SetHeight(nameContainer->GetHeight());
+                node->ToggleVisibility(false);
+                node->SetPositionShort(
+                    (short)(nameContainer->GetXShort() - 5),
+                    (short)(nameContainer->GetYShort() + 3)
+                );
+                node->DrawFlags       |= 1;
+                node->TextFlags       =  8;
+                node->TextFlags2      =  0;
+                node->FontType        =  FontType.MiedingerMed;
+                node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+                node->EdgeColor       =  new ByteColor { R = 255, G = 162, B = 0, A   = 157 };
+                node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+                node->AlignmentType   =  AlignmentType.TopRight;
+
+                LinkNodeAtEnd((AtkResNode*)node, partyMember.PartyMemberComponent->OwnerNode->Component);
+            }
+        }
+
+        private static void EnableShieldNodes(AddonPartyList* addonPartyList)
+        {
+            foreach (var index in Enumerable.Range(0, 8))
+            {
+                ref var partyMember = ref addonPartyList->PartyMembers[index];
+                ref var hpComponent = ref partyMember.HPGaugeComponent;
+                var     numNode     = hpComponent->GetTextNodeById(2);
+
+                if (!TryMakeTextNode(ShieldNodeId, out var node))
+                    continue;
+                shieldNodes[index] = (nint)node;
+
+                node->FontSize = 8;
+                node->AtkResNode.SetWidth(numNode->GetWidth());
+                node->AtkResNode.SetHeight(numNode->GetHeight());
+                node->ToggleVisibility(false);
+                node->SetPositionShort(
+                    (short)(numNode->GetXShort() + numNode->GetWidth() + 2),
+                    (short)(numNode->GetYShort() + 3)
+                );
+                node->DrawFlags       |= 1;
+                node->TextFlags       =  8;
+                node->TextFlags2      =  0;
+                node->FontType        =  FontType.MiedingerMed;
+                node->TextColor       =  new ByteColor { R = 255, G = 225, B = 255, A = 255 };
+                node->EdgeColor       =  new ByteColor { R = 255, G = 162, B = 0, A   = 157 };
+                node->BackgroundColor =  new ByteColor { R = 0, G   = 0, B   = 0, A   = 0 };
+                node->AlignmentType   =  AlignmentType.Left;
+
+                LinkNodeAtEnd((AtkResNode*)node, hpComponent->OwnerNode->Component);
+            }
+        }
+
+        public static void OnPartyListFinalize(AddonEvent type, AddonArgs args)
+            => Disable((AddonPartyList*)args.Addon);
+
+        public static void Disable(AddonPartyList* addonPartyList)
+        {
+            DService.Framework.RunOnFrameworkThread(() =>
+            {
+                if (!hasBuilt)
+                    return;
+
+                DisableMitigationNodes(addonPartyList);
+                DisableShieldNodes(addonPartyList);
+
+                hasBuilt = false;
+            });
+        }
+
+        private static void DisableMitigationNodes(AddonPartyList* addonPartyList)
+        {
+            foreach (var index in Enumerable.Range(0, 8))
+            {
+                ref var partyMember = ref addonPartyList->PartyMembers[index];
+                UnlinkAndFreeTextNode((AtkTextNode*)mitigationNodes[index], partyMember.PartyMemberComponent->OwnerNode);
+            }
+        }
+
+        private static void DisableShieldNodes(AddonPartyList* addonPartyList)
+        {
+            foreach (var index in Enumerable.Range(0, 8))
+            {
+                ref var partyMember = ref addonPartyList->PartyMembers[index];
+                ref var hpComponent = ref partyMember.HPGaugeComponent;
+                UnlinkAndFreeTextNode((AtkTextNode*)shieldNodes[index], hpComponent->OwnerNode);
+            }
+        }
+
+        public static void Update()
+        {
+            if (PartyList is null || !hasBuilt)
+                return;
+
+            foreach (uint index in Enumerable.Range(0, 8))
+            {
+                UpdateMitigationNode(index, [0, 0, 0]);
+                UpdateShieldNode(index, [0, 0, 0]);
+            }
+
+            foreach (var memberStatus in MitigationService.FetchParty())
+            {
+                if (FetchMemberIndex(memberStatus.Key) is { } memberIndex)
+                {
+                    UpdateMitigationNode(memberIndex, memberStatus.Value);
+                    UpdateShieldNode(memberIndex, memberStatus.Value);
                 }
             }
         }
-        catch (Exception ex)
+
+        private static void UpdateMitigationNode(uint memberIndex, float[] memberStatus)
         {
-            Error($"[AutoDisplayMitigationInfo] Fetch Remote Version Failed: {ex}");
+            var nameNode = PartyList->PartyMembers[(int)memberIndex].Name;
+            var node     = (AtkTextNode*)mitigationNodes[(int)memberIndex];
+
+            if (memberStatus[0] == 0 && memberStatus[1] == 0)
+            {
+                node->ToggleVisibility(false);
+                return;
+            }
+
+            var desc = $"{Math.Max(memberStatus[0], memberStatus[1]):N0}%";
+
+            node->ToggleVisibility(nameNode->IsVisible());
+            node->SetText(desc);
         }
 
-        // build cache
-        UpdateMitigationStatusMap();
+        private static void UpdateShieldNode(uint memberIndex, float[] memberStatus)
+        {
+            var node = (AtkTextNode*)shieldNodes[(int)memberIndex];
+
+            if (memberStatus[2] == 0)
+            {
+                node->ToggleVisibility(false);
+                return;
+            }
+
+            var desc = $"{memberStatus[2]:F0}";
+
+            node->ToggleVisibility(true);
+            node->SetText(desc);
+        }
+
+        #endregion
     }
 
-    private async Task FetchMitigationStatuses()
+    #endregion
+
+    #region DamageMonitor
+
+    public static class DamageActionManager
     {
-        try
+        // cache
+        public static Dictionary<uint, DamageAction> Actions       = [];
+        public static DamageAction                   CurrentAction = new() { ActionId = 0 };
+
+        #region Structs
+
+        public struct DamageAction
         {
-            var json = await HttpClientHelper.Get().GetStringAsync($"{SuCache}/mitigation?v={ModuleConfig.LocalCacheVersion}");
-            var resp = JsonConvert.DeserializeObject<MitigationStatus[]>(json);
-            if (resp == null)
-                Error($"[AutoDisplayMitigationInfo] Deserialize Mitigation List Failed: {json}");
-            else
+            [JsonProperty("zone_id")]
+            public uint ZoneId { get; set; }
+
+            [JsonProperty("entity_id")]
+            public uint EntityId { get; set; }
+
+            [JsonProperty("action_id")]
+            public uint ActionId { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("range")]
+            public string Range { get; set; }
+
+            [JsonProperty("damage")]
+            public float Damage { get; set; }
+
+            [JsonProperty("duration")]
+            public float Duration { get; set; }
+        }
+
+        public enum EffectType : byte
+        {
+            Nothing                   = 0,
+            Miss                      = 1,
+            FullResist                = 2,
+            Damage                    = 3,
+            Heal                      = 4,
+            BlockedDamage             = 5,
+            ParriedDamage             = 6,
+            Invulnerable              = 7,
+            NoEffectText              = 8,
+            MpLoss                    = 10,
+            MpGain                    = 11,
+            TpLoss                    = 12,
+            TpGain                    = 13,
+            ApplyStatusEffectTarget   = 14,
+            ApplyStatusEffectSource   = 15,
+            RecoveredFromStatusEffect = 16,
+            LoseStatusEffectTarget    = 17,
+            LoseStatusEffectSource    = 18,
+            StatusNoEffect            = 20,
+            ThreatPosition            = 24,
+            EnmityAmountUp            = 25,
+            EnmityAmountDown          = 26,
+            StartActionCombo          = 27,
+            Knockback                 = 33,
+            Mount                     = 40,
+            FullResistStatus          = 55,
+            Vfx                       = 59,
+            Gauge                     = 60,
+            PartialInvulnerable       = 74,
+            Interrupt                 = 75,
+        }
+
+        public enum EffectDisplayType : byte
+        {
+            HideActionName = 0,
+            ShowActionName = 1,
+            ShowItemName   = 2,
+            MountName      = 13
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct EffectHeader
+        {
+            public uint AnimationTargetId;
+
+            public uint Unknown1;
+
+            public uint ActionId;
+
+            public uint GlobalEffectCounter;
+
+            public float AnimationLockTime;
+
+            public uint Unknown2;
+
+            public ushort HiddenAnimation;
+
+            public ushort Rotation;
+
+            public ushort ActionAnimationId;
+
+            public byte Variation;
+
+            public EffectDisplayType EffectDisplayType;
+
+            public byte Unknown3;
+
+            public byte EffectCount;
+
+            public ushort Unknown4;
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct Effect
+        {
+            public EffectType EffectType;
+            public byte       Param0;
+            public byte       Param1;
+            public byte       Param2;
+            public byte       Flags1;
+            public byte       Flags2;
+            public ushort     Value;
+        }
+
+        #endregion
+
+        #region Hooks
+
+        // start cast hook
+        private static readonly CompSig                  startCastSig = new("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 89 BC 24 D0 00 00 00");
+        private static          Hook<StartCastDelegate>? startCastHook;
+
+        // start cast delegate
+        private unsafe delegate nint StartCastDelegate(BattleChara* player, ActionType type, uint actionId, nint a4, float rotation, float a6);
+
+        // complete cast hook
+        private static readonly CompSig                     completeCastSig = new("E8 ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 45 33 C0 48 8D 0D");
+        private static          Hook<CompleteCastDelegate>? completeCastHook;
+
+        // complete cast delegate
+        private unsafe delegate nint CompleteCastDelegate(
+            BattleChara* player,   ActionType type,     uint  actionId,               uint spellId,            GameObjectId animationTargetId,
+            Vector3*     location, float      rotation, short lastUsedActionSequence, int  animationVariation, int          ballistaEntityId
+        );
+
+        // action effect hook
+        private static readonly CompSig                       actionEffectSig = new("E8 ?? ?? ?? ?? 48 8B 8D F0 03 00 00");
+        private static          Hook<OnActionEffectDelegate>? actionEffectHook;
+
+        // action effect delegate
+        private unsafe delegate void OnActionEffectDelegate(int sourceId, BattleChara* player, Vector3* location, EffectHeader* effectHeader, Effect* effectArray, ulong* effectTrail);
+
+        public static unsafe void Enable()
+        {
+            startCastHook?.Dispose();
+            startCastHook = startCastSig.GetHook<StartCastDelegate>(OnStartCast);
+            startCastHook.Enable();
+
+            completeCastHook?.Dispose();
+            completeCastHook = completeCastSig.GetHook<CompleteCastDelegate>(OnCompleteCast);
+            completeCastHook.Enable();
+
+            actionEffectHook?.Dispose();
+            actionEffectHook = actionEffectSig.GetHook<OnActionEffectDelegate>(OnActionEffect);
+            actionEffectHook.Enable();
+
+            // auto emit from pipe
+            actionPipe = new();
+            Task.Run(ListenAction);
+        }
+
+        public static void Disable()
+        {
+            startCastHook?.Dispose();
+            completeCastHook?.Dispose();
+            actionEffectHook?.Dispose();
+
+            // auto emit from pipe
+            actionPipe?.Cancel();
+        }
+
+        private static unsafe nint OnStartCast(BattleChara* player, ActionType type, uint actionId, nint a4, float rotation, float a6)
+        {
+            // auto emit from cache
+            if (CurrentAction.ActionId == 0)
+                FindAction(actionId);
+
+            return startCastHook.Original(player, ActionType.Action, actionId, a4, rotation, a6);
+        }
+
+        private static unsafe nint OnCompleteCast(
+            BattleChara* player,   ActionType type,     uint  actionId,               uint spellId,            GameObjectId animationTargetId,
+            Vector3*     location, float      rotation, short lastUsedActionSequence, int  animationVariation, int          ballistaEntityId
+        )
+        {
+            // auto clear (duration = 0)
+            if (CurrentAction.ActionId == actionId && CurrentAction.Duration == 0)
+                ClearAction();
+
+            return completeCastHook.Original(player, type, actionId, spellId, animationTargetId, location, rotation, lastUsedActionSequence, animationVariation, ballistaEntityId);
+        }
+
+        private static unsafe void OnActionEffect(int sourceId, BattleChara* player, Vector3* location, EffectHeader* effectHeader, Effect* effectArray, ulong* effectTrail)
+        {
+            actionEffectHook.Original(sourceId, player, location, effectHeader, effectArray, effectTrail);
+
+            try
             {
-                ModuleConfig.MitigationStatuses = resp;
-                SaveConfig(ModuleConfig);
+                for (var i = 0; i < effectHeader->EffectCount; i++)
+                {
+                    var targetId = (uint)(effectTrail[i] & uint.MaxValue);
+                    var actionId = effectHeader->EffectDisplayType switch
+                    {
+                        EffectDisplayType.MountName => 0xD_000_000 + effectHeader->ActionId,
+                        EffectDisplayType.ShowItemName => 0x2_000_000 + effectHeader->ActionId,
+                        _ => effectHeader->ActionAnimationId
+                    };
+
+                    for (var j = 0; j < 8; j++)
+                    {
+                        ref var effect = ref effectArray[i * 8 + j];
+                        if (effect.EffectType == 0)
+                            continue;
+
+                        // unzip damage [high8: Flag1, low16: Value]
+                        uint damage = effect.Value;
+                        if ((effect.Flags2 & 0x40) == 0x40)
+                            damage += (uint)effect.Flags1 << 16;
+                    }
+                }
+            }
+            catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] 技能生效回调解析失败: {ex}"); }
+        }
+
+        #endregion
+
+        #region Action
+
+        private static void FindAction(uint actionId)
+        {
+            // match action from cache
+            if (!Actions.TryGetValue(actionId, out CurrentAction))
+                return;
+
+            // duration?
+            if (CurrentAction.Duration > 0)
+                Task.Run(async () => await Timer.Emit(ClearAction, (int)(CurrentAction.Duration * 1000)));
+        }
+
+        private static CancellationTokenSource? actionPipe;
+
+        private static void ListenAction()
+        {
+            return;
+            while (!actionPipe.IsCancellationRequested)
+            {
+                using var pipe = new NamedPipeServerStream("DR-ADMI", PipeDirection.In, 4);
+                pipe.WaitForConnection();
+
+                try
+                {
+                    using var reader = new StreamReader(pipe);
+                    var       json   = reader.ReadLine();
+                    if (string.IsNullOrEmpty(json))
+                        continue;
+
+
+                    CurrentAction = JsonConvert.DeserializeObject<DamageAction>(json);
+                    if (CurrentAction.Duration > 0)
+                        Task.Run(async () => await Timer.Emit(ClearAction, (int)(CurrentAction.Duration * 1000)));
+                }
+                catch (Exception ex) { Error($"[AutoDisplayMitigationInfo] Damage Action Pipe Listen Failed: {ex}"); }
             }
         }
-        catch (Exception ex)
+
+        private static void ClearAction()
+            => CurrentAction = new DamageAction() { ActionId = 0 };
+
+        #endregion
+
+        #region Funcs
+
+        public static float FetchLocalDamage()
         {
-            Error($"[AutoDisplayMitigationInfo] Fetch Mitigation List Failed: {ex}");
+            if (CurrentAction.ActionId == 0)
+                return 0;
+
+            var status = MitigationService.FetchLocal();
+            var mitigation = CurrentAction.Type switch
+            {
+                "Physical" => status[0],
+                "Magical" => status[1],
+                _ => 0
+            };
+            var shield = status[2];
+
+            return CurrentAction.Damage * (1 - (mitigation / 100)) - shield;
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Timer
+
+    public static class Timer
+    {
+        private static CancellationTokenSource? cts;
+
+        public static async Task Emit(Action onElapsed, int delay)
+        {
+            // cancel previous timer
+            cts?.Cancel();
+            cts?.Dispose();
+
+            // create a new timer
+            cts = new CancellationTokenSource();
+            var token = cts.Token;
+
+            try
+            {
+                await Task.Delay(delay, token);
+
+                // check if the token is not canceled
+                if (!token.IsCancellationRequested)
+                    onElapsed();
+            }
+            catch (TaskCanceledException) { }
         }
     }
 
     #endregion
 
+    #region Mitigation
+
+    public unsafe class MitigationManager(MitigationManager.Storage config)
+    {
+        // cache
+        private Dictionary<uint, Status> statusDict = [];
+
+        // local player
+        public readonly Dictionary<Status, float> LocalActiveStatus = [];
+
+        public float LocalShield
+        {
+            get
+            {
+                var localPlayer = Control.GetLocalPlayer();
+                if (localPlayer == null)
+                    return 0;
+
+                return (float)localPlayer->ShieldValue / 100 * localPlayer->Health;
+            }
+        }
+
+        // party member
+        public readonly Dictionary<uint, Dictionary<Status, float>> PartyActiveStatus = [];
+
+        public Dictionary<uint, float> PartyShield
+        {
+            get
+            {
+                var partyShield = new Dictionary<uint, float>();
+
+                var partyList = DService.PartyList;
+                if (partyList.Count == 0)
+                    return partyShield;
+
+                foreach (var member in partyList)
+                {
+                    if (member.ObjectId == 0)
+                        continue;
+
+                    if (DService.ObjectTable.SearchById(member.ObjectId) is ICharacter memberChara)
+                        partyShield[member.ObjectId] = ((float)memberChara.ShieldPercentage / 100 * memberChara.CurrentHp);
+                }
+
+                return partyShield;
+            }
+        }
+
+        // battle npc
+        public readonly Dictionary<Status, float> BattleNpcActiveStatus = [];
+
+        // config
+        public class Storage
+        {
+            public Status[] Statuses = [];
+        }
+
+        #region Structs
+
+        public struct StatusInfo
+        {
+            [JsonProperty("physical")]
+            public float Physical { get; private set; }
+
+            [JsonProperty("magical")]
+            public float Magical { get; private set; }
+        }
+
+        public struct Status : IEquatable<Status>
+        {
+            [JsonProperty("id")]
+            public uint Id { get; private set; }
+
+            [JsonProperty("name")]
+            public string Name { get; private set; }
+
+            [JsonProperty("mitigation")]
+            public StatusInfo Info { get; private set; }
+
+            [JsonProperty("on_member")]
+            public bool OnMember { get; private set; }
+
+            #region Equals
+
+            public bool Equals(Status other) => Id == other.Id;
+
+            public override bool Equals(object? obj) => obj is Status other && Equals(other);
+
+            public override int GetHashCode() => (int)Id;
+
+            public static bool operator ==(Status left, Status right) => left.Equals(right);
+
+            public static bool operator !=(Status left, Status right) => !left.Equals(right);
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Funcs
+
+        public void InitStatusMap()
+            => statusDict = config.Statuses.ToDictionary(x => x.Id, x => x);
+
+        public void Update()
+        {
+            // clear cache
+            Clear();
+
+            // local player
+            var localPlayer = Control.GetLocalPlayer();
+            if (localPlayer == null)
+                return;
+
+            // status
+            foreach (var status in localPlayer->StatusManager.Status)
+            {
+                if (statusDict.TryGetValue(status.StatusId, out var mitigation))
+                    LocalActiveStatus.TryAdd(mitigation, status.RemainingTime);
+            }
+
+            // party
+            var partyList = DService.PartyList;
+            if (partyList.Count != 0)
+            {
+                foreach (var member in partyList)
+                {
+                    if (member.ObjectId == 0)
+                        continue;
+
+                    var activeStatus = new Dictionary<Status, float>();
+                    foreach (var status in member.Statuses)
+                    {
+                        if (statusDict.TryGetValue(status.StatusId, out var mitigation))
+                            activeStatus.TryAdd(mitigation, status.RemainingTime);
+                    }
+
+                    PartyActiveStatus[member.ObjectId] = activeStatus;
+                }
+            }
+
+            // battle npc
+            var currentTarget = DService.Targets.Target;
+            if (currentTarget is IBattleNpc battleNpc)
+            {
+                var statusList = battleNpc.ToBCStruct()->StatusManager.Status;
+                foreach (var status in statusList)
+                {
+                    if (statusDict.TryGetValue(status.StatusId, out var mitigation))
+                        BattleNpcActiveStatus.TryAdd(mitigation, status.RemainingTime);
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            LocalActiveStatus.Clear();
+            PartyActiveStatus.Clear();
+            BattleNpcActiveStatus.Clear();
+        }
+
+        public bool IsLocalEmpty()
+            => LocalActiveStatus.Count == 0 && LocalShield == 0 && BattleNpcActiveStatus.Count == 0;
+
+        public float[] FetchLocal()
+        {
+            var activeStatus = LocalActiveStatus.Concat(BattleNpcActiveStatus).ToDictionary(kv => kv.Key, kv => kv.Value);
+            return
+            [
+                Reduction(activeStatus.Keys.Select(x => x.Info.Physical)),
+                Reduction(activeStatus.Keys.Select(x => x.Info.Magical)),
+                LocalShield
+            ];
+        }
+
+        public Dictionary<uint, float[]> FetchParty()
+        {
+            if (DService.PartyList.Count == 0)
+                return new Dictionary<uint, float[]>() { { GameState.EntityID, FetchLocal() } };
+
+            var partyValues = new Dictionary<uint, float[]>();
+            foreach (var memberActiveStatus in PartyActiveStatus)
+            {
+                var activeStatus = memberActiveStatus.Value.Concat(BattleNpcActiveStatus).ToDictionary(kv => kv.Key, kv => kv.Value);
+                partyValues[memberActiveStatus.Key] =
+                [
+                    Reduction(activeStatus.Keys.Select(x => x.Info.Physical)),
+                    Reduction(activeStatus.Keys.Select(x => x.Info.Magical)),
+                    PartyShield.GetValueOrDefault(memberActiveStatus.Key, 0)
+                ];
+            }
+
+            return partyValues;
+        }
+
+
+        public static float Reduction(IEnumerable<float> mitigations) =>
+            (1f - mitigations.Aggregate(1f, (acc, m) => acc * (1f - (m / 100f)))) * 100f;
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Utils
+
+    private static unsafe uint? FetchMemberIndex(uint entityId)
+        => AgentHUD.Instance()->PartyMembers.ToArray()
+                                            .Select((m, i) => (Member: m, Index: (uint)i))
+                                            .FirstOrDefault(t => t.Member.EntityId == entityId).Index;
+
+    #endregion
+
     #region Config
 
-    private class Config : ModuleConfiguration
+    private class ModuleStorage : ModuleConfiguration
     {
+        // mitigation
+        public readonly MitigationManager.Storage MitigationStorage = new();
+
+        // activate
         public bool OnlyInCombat = true;
-        
+
+        // ui
         public bool TransparentOverlay;
         public bool ResizeableOverlay = true;
-        public bool MoveableOverlay = true;
-
-        // remote cache
-        public string             LocalCacheVersion  = "0.0.0";
-        public MitigationStatus[] MitigationStatuses = [];
-    }
-
-    public struct MitigationDetail
-    {
-        [JsonProperty("physical")]
-        public float Physical { get; private set; }
-
-        [JsonProperty("magical")]
-        public float Magical { get; private set; }
-
-        [JsonProperty("special")]
-        public float Special { get; private set; }
-    }
-
-    public struct MitigationStatus : IEquatable<MitigationStatus>
-    {
-        [JsonProperty("id")]
-        public uint Id { get; private set; }
-
-        [JsonProperty("name")]
-        public string Name { get; private set; }
-
-        [JsonProperty("mitigation")]
-        public MitigationDetail Mitigation { get; private set; }
-
-        [JsonProperty("on_member")]
-        public bool OnMember { get; private set; }
-
-        public bool Equals(MitigationStatus other) => Id == other.Id;
-
-        public override bool Equals(object? obj) => obj is MitigationStatus other && Equals(other);
-
-        public override int GetHashCode() => (int)Id;
-
-        public static bool operator ==(MitigationStatus left, MitigationStatus right) => left.Equals(right);
-
-        public static bool operator !=(MitigationStatus left, MitigationStatus right) => !left.Equals(right);
+        public bool MoveableOverlay   = true;
     }
 
     #endregion

--- a/Combat/TimedBuffReminder.cs
+++ b/Combat/TimedBuffReminder.cs
@@ -50,10 +50,10 @@ public class TimedBuffReminder : DailyModuleBase
         // fetch remote resource
         RemoteRepoManager.FetchTimedBuffList().Wait(); // wait for init action select
 
-        // action select combo
+        // status select combo
         StatusSelect ??= new("##StatusSelect", LuminaGetter.Get<Status>().Where(x => StatusMonitor.StatusDict.ContainsKey(x.RowId)));
         if (moduleConfig.StatusStorage.EnabledStatusIds.Count == 0)
-            moduleConfig.StatusStorage.EnabledStatusIds = new HashSet<uint>(StatusMonitor.StatusDict.Select(x => x.Key));
+            moduleConfig.StatusStorage.EnabledStatusIds = StatusMonitor.StatusDict.Keys.ToHashSet();
         StatusSelect.SelectedStatusIDs = moduleConfig.StatusStorage.EnabledStatusIds;
 
         // highlight manager

--- a/Combat/TimedBuffReminder.cs
+++ b/Combat/TimedBuffReminder.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using DailyRoutines.Abstracts;
+using DailyRoutines.Helpers;
+using DailyRoutines.Managers;
+using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Control;
+using Newtonsoft.Json;
+using LuminaAction = Lumina.Excel.Sheets.Action;
+
+namespace DailyRoutines.ModulesPublic;
+
+public class TimedBuffReminder : DailyModuleBase
+{
+    #region Core
+
+    // info
+    public override ModuleInfo Info { get; } = new()
+    {
+        Title       = GetLoc("TimedBuffReminderTitle"),
+        Description = GetLoc("TimedBuffReminderDescription"),
+        Category    = ModuleCategories.Combat,
+        Author      = ["HaKu"]
+    };
+
+    // storage
+    private static ModuleStorage? moduleConfig;
+
+    // managers
+    private static StatusMonitor statusService;
+
+    public override void Init()
+    {
+        moduleConfig = LoadConfig<ModuleStorage>() ?? new ModuleStorage();
+
+        // status monitor
+        statusService = new StatusMonitor(moduleConfig.StatusStorage);
+
+        // fetch remote resource
+        Task.Run(async () => await RemoteRepoManager.FetchTimedBuffList());
+
+        // highlight manager
+        UseActionManager.RegPreUseActionLocation(OnPreUseAction);
+        HighlightManager.Enable();
+
+        // refresh highlight
+        FrameworkManager.Register(OnFrameworkUpdateInterval, throttleMS: 200);
+    }
+
+    public override void Uninit()
+    {
+        UseActionManager.UnregPreUseActionLocation(OnPreUseAction);
+        HighlightManager.Disable();
+        FrameworkManager.Unregister(OnFrameworkUpdateInterval);
+
+        base.Uninit();
+    }
+
+    public override void ConfigUI()
+    {
+        ImGui.TextColored(LightGreen, GetLoc("TimedBuffReminder-Threshold"));
+        ImGui.Spacing();
+        if (ImGui.SliderFloat("##ReminderThreshold", ref moduleConfig.StatusStorage.Threshold, 2.0f, 10.0f, "%.1f"))
+            SaveConfig(moduleConfig);
+    }
+
+    #endregion
+
+    #region Hooks
+
+    private static unsafe void OnFrameworkUpdateInterval(IFramework _)
+    {
+        if (DService.ClientState.IsPvP || !DService.Condition[ConditionFlag.InCombat] || Control.GetLocalPlayer() is null)
+            return;
+
+        // update status
+        statusService.Update();
+    }
+
+    private static void OnPreUseAction(
+        ref bool  isPrevented, ref ActionType type,     ref uint actionId,
+        ref ulong targetId,    ref Vector3    location, ref uint extraParam
+    )
+    {
+        HighlightManager.HighlightActions.Remove(actionId);
+        statusService.LastActionId = actionId;
+    }
+
+    #endregion
+
+    #region RemoteCache
+
+    private static class RemoteRepoManager
+    {
+        // const
+        private const string Uri = "https://dr-cache.sumemo.dev";
+
+        public static async Task FetchTimedBuffList()
+        {
+            try
+            {
+                var json = await HttpClientHelper.Get().GetStringAsync($"{Uri}/timed-buff");
+                var resp = JsonConvert.DeserializeObject<List<StatusMonitor.Status>>(json);
+                if (resp == null)
+                    Error($"[TimedBuffReminder] 远程延续性状态文件解析失败: {json}");
+                else
+                {
+                    moduleConfig.StatusStorage.Statuses = resp.ToArray();
+                    statusService.InitStatusMap();
+                }
+            }
+            catch (Exception ex) { Error($"[TimedBuffReminder] 远程延续性状态文件获取失败: {ex}"); }
+        }
+    }
+
+    #endregion
+
+    #region HighlightManager
+
+    private static class HighlightManager
+    {
+        // cache
+        public static readonly HashSet<uint> HighlightActions = [];
+
+        #region Hooks
+
+        // is action highlight
+        private static readonly CompSig                                            isActionHighlightedSig = new("E8 ?? ?? ?? ?? 88 46 41 80 BF ?? ?? ?? ?? ?? ??");
+        private static          Hook<ActionManager.Delegates.IsActionHighlighted>? isActionHighlightedHook;
+
+        public static unsafe void Enable()
+        {
+            isActionHighlightedHook?.Dispose();
+            isActionHighlightedHook = isActionHighlightedSig.GetHook<ActionManager.Delegates.IsActionHighlighted>(IsActionHighlightedDetour);
+            isActionHighlightedHook.Enable();
+        }
+
+        public static void Disable()
+            => isActionHighlightedHook?.Dispose();
+
+        private static unsafe bool IsActionHighlightedDetour(ActionManager* actionManager, ActionType actionType, uint actionId)
+            => HighlightActions.Contains(actionId) || isActionHighlightedHook!.Original(actionManager, actionType, actionId);
+
+        #endregion
+    }
+
+    #endregion
+
+    #region StatusMonitor
+
+    private unsafe class StatusMonitor(StatusMonitor.Storage config)
+    {
+        // cache
+        private         Dictionary<uint, Status>  statusDict       = [];
+        public readonly Dictionary<Status, float> ActiveStatusList = [];
+        public          uint                      LastActionId;
+
+        // config
+        public class Storage
+        {
+            public Status[] Statuses  = [];
+            public float    Threshold = 3.0f;
+        }
+
+        #region Funcs
+
+        public void InitStatusMap()
+            => statusDict = config.Statuses.ToDictionary(x => x.StatusId, x => x);
+
+        public void Update()
+        {
+            // clear cache
+            Clear();
+
+            // local player
+            var localPlayer = Control.GetLocalPlayer();
+            if (localPlayer == null)
+                return;
+
+            // status
+            foreach (var status in localPlayer->StatusManager.Status)
+            {
+                if (statusDict.TryGetValue(status.StatusId, out var mitigation))
+                    ActiveStatusList.TryAdd(mitigation, status.RemainingTime);
+            }
+
+            // battle npc
+            var currentTarget = DService.Targets.Target;
+            if (currentTarget is IBattleNpc battleNpc)
+            {
+                foreach (var status in battleNpc.ToBCStruct()->StatusManager.Status)
+                {
+                    if (statusDict.TryGetValue(status.StatusId, out var mitigation))
+                        ActiveStatusList.TryAdd(mitigation, status.RemainingTime);
+                }
+            }
+
+            // refresh highlight
+            var manager = ActionManager.Instance();
+            HighlightManager.HighlightActions.Clear();
+            foreach (var status in ActiveStatusList)
+            {
+                foreach (var actionId in status.Key.ActionId)
+                {
+                    var actionChain = FetchComboChain(actionId);
+
+                    var cutoff        = config.Threshold * actionChain.Length;
+                    var notInChain    = actionChain.All(id => !manager->IsActionHighlighted(ActionType.Action, id));
+                    var notLastAction = actionChain[..^1].All(id => id != LastActionId);
+
+                    if (status.Value <= cutoff && notInChain && notLastAction)
+                        HighlightManager.HighlightActions.Add(actionChain[0]);
+                }
+            }
+        }
+
+        public void Clear()
+            => ActiveStatusList.Clear();
+
+        #endregion
+
+        public struct Status : IEquatable<Status>
+        {
+            [JsonProperty("status_id")]
+            public uint StatusId { get; private set; }
+
+            [JsonProperty("action_id")]
+            public uint[] ActionId { get; private set; }
+
+            [JsonProperty("name")]
+            public string Name { get; private set; }
+
+            #region Equals
+
+            public bool Equals(Status other) => StatusId == other.StatusId;
+
+            public override bool Equals(object? obj) => obj is Status other && Equals(other);
+
+            public override int GetHashCode() => (int)StatusId;
+
+            public static bool operator ==(Status left, Status right) => left.Equals(right);
+
+            public static bool operator !=(Status left, Status right) => !left.Equals(right);
+
+            #endregion
+        }
+
+        #region Funcs
+
+        private static uint[] FetchComboChain(uint actionId)
+        {
+            var chain = new List<uint>();
+
+            var cur = actionId;
+            while (cur != 0 && LuminaGetter.TryGetRow<LuminaAction>(cur, out var action))
+            {
+                chain.Add(cur);
+
+                var comboRef = action.ActionCombo;
+                if (comboRef.RowId == 0)
+                    break;
+                cur = comboRef.RowId;
+            }
+
+            chain.Reverse();
+            return chain.ToArray();
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Config
+
+    private class ModuleStorage : ModuleConfiguration
+    {
+        // status
+        public readonly StatusMonitor.Storage StatusStorage = new();
+    }
+
+    #endregion
+}

--- a/Combat/TimedBuffReminder.cs
+++ b/Combat/TimedBuffReminder.cs
@@ -132,13 +132,16 @@ public class TimedBuffReminder : DailyModuleBase
         #region Hooks
 
         // is action highlight
-        private static readonly CompSig                                            isActionHighlightedSig = new("E8 ?? ?? ?? ?? 88 46 41 80 BF ?? ?? ?? ?? ?? ??");
-        private static          Hook<ActionManager.Delegates.IsActionHighlighted>? isActionHighlightedHook;
+        [return: MarshalAs(UnmanagedType.U1)]
+        private unsafe delegate bool IsActionHighlightedDelegate(ActionManager* actionManager, ActionType actionType, uint actionId);
+
+        private static readonly CompSig                            isActionHighlightedSig = new("E8 ?? ?? ?? ?? 88 46 41 80 BF ?? ?? ?? ?? ?? ??");
+        private static          Hook<IsActionHighlightedDelegate>? isActionHighlightedHook;
 
         public static unsafe void Enable()
         {
             isActionHighlightedHook?.Dispose();
-            isActionHighlightedHook = isActionHighlightedSig.GetHook<ActionManager.Delegates.IsActionHighlighted>(IsActionHighlightedDetour);
+            isActionHighlightedHook = isActionHighlightedSig.GetHook<IsActionHighlightedDelegate>(IsActionHighlightedDetour);
             isActionHighlightedHook.Enable();
         }
 

--- a/Combat/TimedBuffReminder.cs
+++ b/Combat/TimedBuffReminder.cs
@@ -37,8 +37,7 @@ public class TimedBuffReminder : DailyModuleBase
     private static StatusMonitor statusService;
 
     // ui
-    public StatusSelectCombo? StatusSelect;
-
+    private static StatusSelectCombo? statusSelect;
 
     public override void Init()
     {
@@ -51,10 +50,10 @@ public class TimedBuffReminder : DailyModuleBase
         RemoteRepoManager.FetchTimedBuffList().Wait(); // wait for init action select
 
         // status select combo
-        StatusSelect ??= new("##StatusSelect", LuminaGetter.Get<Status>().Where(x => StatusMonitor.StatusDict.ContainsKey(x.RowId)));
+        statusSelect ??= new("##StatusSelect", LuminaGetter.Get<Status>().Where(x => StatusMonitor.StatusDict.ContainsKey(x.RowId)));
         if (moduleConfig.StatusStorage.EnabledStatusIds.Count == 0)
             moduleConfig.StatusStorage.EnabledStatusIds = StatusMonitor.StatusDict.Keys.ToHashSet();
-        StatusSelect.SelectedStatusIDs = moduleConfig.StatusStorage.EnabledStatusIds;
+        statusSelect.SelectedStatusIDs = moduleConfig.StatusStorage.EnabledStatusIds;
 
         // highlight manager
         UseActionManager.RegPreUseActionLocation(OnPreUseAction);
@@ -82,9 +81,9 @@ public class TimedBuffReminder : DailyModuleBase
 
         ImGui.Spacing();
 
-        if (StatusSelect.DrawCheckbox())
+        if (statusSelect.DrawCheckbox())
         {
-            moduleConfig.StatusStorage.EnabledStatusIds = StatusSelect.SelectedStatusIDs;
+            moduleConfig.StatusStorage.EnabledStatusIds = statusSelect.SelectedStatusIDs;
             SaveConfig(moduleConfig);
         }
     }


### PR DESCRIPTION
**减伤显示** 修复

1. 在小队列表中直接显示每个成员的减伤和护盾信息
2. 部分副本的部分技能的预期伤害会直接显示在敌方读条旁 【热更新】
3. 移除了不必要的持久化文件

**治疗优化**

1. 更新了远程文件访问路径
2. 错误信息现在使用中文
3. 更改了技能选取的逻辑，现在使用 ActionComboSelect
4. 移除了不必要的持久化文件

**延续性状态技能提示**

1. 当 四个治疗的 DoT 状态、龙骑的 DoT 状态、战士的强化状态 倒计时少于用户设置阈值时，高亮对应的技能按钮

~~按钮亮了不点？~~