### PR TITLE
添加模块：取出重复的幻化

### DIFF
--- a/UIOperation/AutoRemoveRepeatGlamour.cs
+++ b/UIOperation/AutoRemoveRepeatGlamour.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using DailyRoutines.Abstracts;
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace DailyRoutines.ModulesPublic;
+
+public class AutoRemoveRepeatGlamour : DailyModuleBase
+{
+    public override ModuleInfo Info { get; } = new()
+    {
+        Title = GetLoc("AutoRemoveRepeatGlamourTitle"),
+        Description = GetLoc("AutoRemoveRepeatGlamourDescription"),
+        Author = ["ECSS11"]
+    };
+
+    protected override void Init() => TaskHelper ??= new TaskHelper { TimeLimitMS = 30_000 };
+
+    private unsafe void GlamourBoxTakeout()
+    {
+        var instance = MirageManager.Instance();
+        if (instance == null) return;
+
+        List<uint> itemIndexToRemove = [];
+        HashSet<uint> itemIndexHash = [];
+        for (var i = 0U; i < 800; i++)
+        {
+            var item = instance->PrismBoxItemIds[(int)i];
+            if (item == 0) continue;
+
+            var itemId = item % 100_0000;
+            if (!itemIndexHash.Add(itemId))
+                itemIndexToRemove.Add(i);
+        }
+
+        if (itemIndexToRemove.Count == 0) return;
+
+        itemIndexToRemove.ForEach(x => TaskHelper.Enqueue(() => instance->RestorePrismBoxItem(x)));
+    }
+
+    protected override void ConfigUI()
+    {
+        if (ImGui.Button(GetLoc("Start")))
+            GlamourBoxTakeout();
+        ImGui.SameLine();
+        if (ImGui.Button(GetLoc("Stop")))
+            TaskHelper.Abort();
+    }
+}

--- a/UIOptimization/GlamourSwitchToCurrentJob.cs
+++ b/UIOptimization/GlamourSwitchToCurrentJob.cs
@@ -27,21 +27,16 @@ public class GlamourSwitchToCurrentJob : DailyModuleBase
         LuminaGetter.TryGetRow<Lumina.Excel.Sheets.ClassJob>(DService.ObjectTable.LocalPlayer.ClassJob.RowId,
                                                              out var job);
         var addon = (AddonMiragePrismPrismBox*)args.Addon;
-
         var currentJob = job.Name.ToString();
 
         // 一种基于暴力循环实现的匹配
-        var counter = 0;
+        var jobDropdownLength = addon->JobDropdown->List->ListLength;
         var pattern = new Regex(@"\b" + currentJob + @"\b");
-        while (true)
+        for (var i = 1; i < jobDropdownLength; i++)
         {
-            counter++;
-            var currentLabel = addon->JobDropdown->List->GetItemLabel(counter).ToString();
+            var currentLabel = addon->JobDropdown->List->GetItemLabel(i).ToString();
             if (pattern.IsMatch(currentLabel))
-                addon->JobDropdown->SelectItem(counter);
-            
-            // 防止意外情况，理论不会发生
-            if (currentLabel.IsNullOrEmpty()) return;
+                addon->JobDropdown->SelectItem(i);
         }
     }
 

--- a/UIOptimization/GlamourSwitchToCurrentJob.cs
+++ b/UIOptimization/GlamourSwitchToCurrentJob.cs
@@ -37,10 +37,10 @@ public class GlamourSwitchToCurrentJob : DailyModuleBase
         {
             counter++;
             var currentLabel = addon->JobDropdown->List->GetItemLabel(counter).ToString();
-            DService.Log.Debug(currentLabel);
             if (pattern.IsMatch(currentLabel))
                 addon->JobDropdown->SelectItem(counter);
-
+            
+            // 防止意外情况，理论不会发生
             if (currentLabel.IsNullOrEmpty()) return;
         }
     }

--- a/UIOptimization/GlamourSwitchToCurrentJob.cs
+++ b/UIOptimization/GlamourSwitchToCurrentJob.cs
@@ -1,0 +1,50 @@
+﻿using System.Text.RegularExpressions;
+using DailyRoutines.Abstracts;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Utility;
+using FFXIVClientStructs.FFXIV.Client.UI;
+
+namespace DailyRoutines.ModulesPublic;
+
+public class GlamourSwitchToCurrentJob : DailyModuleBase
+{
+    public override ModuleInfo Info { get; } = new()
+    {
+        Title = GetLoc("GlamourSwitchToCurrentJobTitle"),
+        Description = GetLoc("GlamourSwitchToCurrentJobDescription"),
+        Category = ModuleCategories.UIOptimization,
+        Author = ["ECSS11"]
+    };
+
+    protected override void Init() => DService.AddonLifecycle.RegisterListener(
+        AddonEvent.PostRequestedUpdate, "MiragePrismPrismBox",
+        OnMiragePrismPrismBox);
+
+    private unsafe void OnMiragePrismPrismBox(AddonEvent type, AddonArgs args)
+    {
+        // 获取当前职业和幻化台 Addon
+        LuminaGetter.TryGetRow<Lumina.Excel.Sheets.ClassJob>(DService.ObjectTable.LocalPlayer.ClassJob.RowId,
+                                                             out var job);
+        var addon = (AddonMiragePrismPrismBox*)args.Addon;
+
+        var currentJob = job.Name.ToString();
+
+        // 一种基于暴力循环实现的匹配
+        var counter = 0;
+        var pattern = new Regex(@"\b" + currentJob + @"\b");
+        while (true)
+        {
+            counter++;
+            var currentLabel = addon->JobDropdown->List->GetItemLabel(counter).ToString();
+            DService.Log.Debug(currentLabel);
+            if (pattern.IsMatch(currentLabel))
+                addon->JobDropdown->SelectItem(counter);
+
+            if (currentLabel.IsNullOrEmpty()) return;
+        }
+    }
+
+    protected override void Uninit() =>
+        DService.AddonLifecycle.UnregisterListener(AddonEvent.PostRequestedUpdate, "MiragePrismPrismBox");
+}


### PR DESCRIPTION
**来源**

[【许愿】取出幻化重复物品](https://discord.com/channels/1258981591124938762/1398522424676319314)

**本地化**

正在添加...

**描述**

一键取出幻化箱中重复的物品。

**原因**

孩子眼睛不好用 `YesAlready` 塞了一堆重复幻化。