### PR TITLE
提交 技能-更好的召唤坐骑

### DIFF
--- a/Action/BetterMountCast.cs
+++ b/Action/BetterMountCast.cs
@@ -1,0 +1,64 @@
+using DailyRoutines.Abstracts;
+using DailyRoutines.Managers;
+using Dalamud.Game.Command;
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace DailyRoutines.ModulesPublic;
+
+public class BetterMountCast : DailyModuleBase
+{
+    public override ModuleInfo Info { get; } = new()
+    {
+        Title = GetLoc("BetterMountCastTitle"),
+        Description = GetLoc("BetterMountCastDescription"),
+        Category = ModuleCategories.Action,
+        Author = ["Bill"],
+        ModulesRecommend = ["BetterMountRoulette"]
+    };
+
+    private static readonly string Command = "mount";
+
+    protected override void Init()
+    {
+        TaskHelper ??= new TaskHelper { AbortOnTimeout = true, TimeLimitMS = 20000, ShowDebug = false };
+
+        CommandManager.AddSubCommand(
+            Command, new CommandInfo(OnCommand) { HelpMessage = GetLoc("BetterMountCast-CommandHelp") });
+    }
+
+    private void OnCommand(string SubCommand, string args)
+    {
+        if (IsCasting && DService.ObjectTable.LocalPlayer.CastActionType == ActionType.Mount)
+            ExecuteCancelCast();
+
+
+        if (!IsCasting && (CanMount || IsOnMount))
+        {
+            TaskHelper.Abort();
+            TaskHelper.Enqueue(UseMount);
+        }
+
+        void ExecuteCancelCast()
+        {
+            if (Throttler.Throttle("BetterMountCast-CancelCast", 100))
+                ExecuteCommandManager.ExecuteCommand(ExecuteCommandFlag.CancelCast);
+        }
+    }
+
+    private unsafe bool? UseMount()
+    {
+        if (!Throttler.Throttle("BetterMountCast-UseMount")) return false;
+        if (ActionManager.Instance()->GetActionStatus(ActionType.GeneralAction, 9) != 0) return false;
+
+        TaskHelper.DelayNext(100);
+        TaskHelper.Enqueue(() => UseActionManager.UseAction(ActionType.GeneralAction, 9));
+        return true;
+    }
+
+    protected override void Uninit()
+    {
+        TaskHelper?.Abort();
+
+        CommandManager.RemoveSubCommand(Command);
+    }
+}


### PR DESCRIPTION
单纯加了一个指令 `/pdr mount` 没上坐骑的时候效果是召唤坐骑，读条召唤坐骑的时候打断读条，在坐骑上下坐骑。这样就能在误触召唤坐骑的时候快速打断读条了（用宏）

感觉可以加点配置啥的）但是感觉没必要）
冲突模块是瞪眼法感觉出来的）如果不会冲突的话猫耳娘大人说一下我删掉）））

（需求来源于群友投稿）