### PR TITLE
自动登录模块修改

### DIFF
--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -536,7 +536,7 @@ public unsafe class AutoLogin : ModuleBase
     #region 常量
 
     private const string COMMAND = "/pdrlogin";
-    private const int    LoginAttemptNoProgressTimeoutMS = 5_000;
+    private const int    LoginAttemptNoProgressTimeoutMS = 2_000;
 
     private static readonly Dictionary<BehaviourMode, string> BehaviourModeLoc = new()
     {

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -35,10 +35,12 @@ public unsafe class AutoLogin : ModuleBase
     private int selectedCharaIndex;
     private int dropIndex = -1;
 
-    private bool   hasLoginOnce;
-    private int    defaultLoginIndex = -1;
-    private ushort manualWorldID;
-    private int    manualCharaIndex = -1;
+    private bool              hasLoginOnce;
+    private int               defaultLoginIndex = -1;
+    private LoginAttemptState loginAttemptState;
+    private long              loginAttemptStartTicks;
+    private ushort            manualWorldID;
+    private int               manualCharaIndex = -1;
 
     protected override void Init()
     {
@@ -119,8 +121,8 @@ public unsafe class AutoLogin : ModuleBase
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200f * GlobalUIScale);
-                        if (ImGui.InputInt("##AutoLogin-EnterCharaIndex", ref selectedCharaIndex, flags: ImGuiInputTextFlags.EnterReturnsTrue))
-                            selectedCharaIndex = Math.Clamp(selectedCharaIndex, 0, 8);
+                        ImGui.InputInt("##AutoLogin-EnterCharaIndex", ref selectedCharaIndex);
+                        selectedCharaIndex = Math.Clamp(selectedCharaIndex, 0, 7);
                         ImGuiOm.TooltipHover(Lang.Get("AutoLogin-CharaIndexInputTooltip"));
                     }
 
@@ -256,8 +258,11 @@ public unsafe class AutoLogin : ModuleBase
         }
     }
 
-    private void OnLogin() =>
+    private void OnLogin()
+    {
+        ResetStates();
         TaskHelper.Abort();
+    }
 
     private void OnCommand(string command, string args)
     {
@@ -322,7 +327,7 @@ public unsafe class AutoLogin : ModuleBase
             TaskHelper.Enqueue(SelectCharacterDefault, "SelectCharaDefault0");
     }
 
-    private static void OnDialogue(AddonEvent type, AddonArgs args)
+    private void OnDialogue(AddonEvent type, AddonArgs args)
     {
         var addon = Dialogue;
         if (!addon->IsAddonAndNodesReady()) return;
@@ -331,14 +336,33 @@ public unsafe class AutoLogin : ModuleBase
         if (buttonNode == null) return;
 
         buttonNode->Click();
+
+        if (IsDefaultLoginFlow && loginAttemptState != LoginAttemptState.None)
+            loginAttemptState = LoginAttemptState.Failed;
     }
 
     private void SelectCharacterDefault()
     {
+        defaultLoginIndex = 0;
+        EnqueueNextDefaultCharacter();
+    }
+
+    private void EnqueueNextDefaultCharacter()
+    {
         if (config.LoginInfos.Count == 0) return;
 
-        var loginInfo = config.LoginInfos[0];
-        defaultLoginIndex = 0;
+        loginAttemptState = LoginAttemptState.None;
+
+        if (defaultLoginIndex < 0) return;
+
+        if (defaultLoginIndex >= config.LoginInfos.Count)
+        {
+            if (config.Mode != BehaviourMode.Repeat) return;
+            defaultLoginIndex = 0;
+        }
+
+        var loginInfo = config.LoginInfos[defaultLoginIndex];
+        defaultLoginIndex++;
         TaskHelper.Enqueue
         (
             () => SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaIndex),
@@ -366,6 +390,47 @@ public unsafe class AutoLogin : ModuleBase
         }
 
         AgentLobbyEvent.SelectCharacterByIndex((uint)charaIndex);
+        if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
+        {
+            loginAttemptState      = LoginAttemptState.Waiting;
+            loginAttemptStartTicks = Environment.TickCount64;
+            TaskHelper.Enqueue
+            (
+                WaitForLoginAttemptResult,
+                $"WaitLoginAttemptResult_{worldID}_{charaIndex}",
+                timeoutAction: EnqueueNextDefaultCharacter
+            );
+        }
+
+        return true;
+    }
+
+    private bool WaitForLoginAttemptResult()
+    {
+        if (DService.Instance().ClientState.IsLoggedIn) return true;
+
+        if (loginAttemptState == LoginAttemptState.Failed)
+        {
+            EnqueueNextDefaultCharacter();
+            return true;
+        }
+
+        if (!CharaSelectListMenu->IsAddonAndNodesReady())
+        {
+            loginAttemptState = LoginAttemptState.CharaSelectLeft;
+            return false;
+        }
+
+        if (loginAttemptState == LoginAttemptState.Waiting &&
+            Environment.TickCount64 - loginAttemptStartTicks >= LoginAttemptNoProgressTimeoutMS)
+        {
+            EnqueueNextDefaultCharacter();
+            return true;
+        }
+
+        if (loginAttemptState != LoginAttemptState.CharaSelectLeft) return false;
+
+        EnqueueNextDefaultCharacter();
         return true;
     }
 
@@ -382,18 +447,7 @@ public unsafe class AutoLogin : ModuleBase
         if (!AgentLobbyEvent.SelectWorldByID(worldID))
         {
             // 没找到
-            TaskHelper.Abort();
-
-            if (defaultLoginIndex != -1 && defaultLoginIndex < config.LoginInfos.Count)
-            {
-                var loginInfo = config.LoginInfos[defaultLoginIndex];
-                defaultLoginIndex++;
-                TaskHelper.Enqueue
-                (
-                    () => SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaIndex),
-                    $"SelectCharaDefault_{loginInfo.WorldID}_{loginInfo.CharaIndex}"
-                );
-            }
+            EnqueueNextDefaultCharacter();
         }
 
         return true;
@@ -403,9 +457,13 @@ public unsafe class AutoLogin : ModuleBase
     {
         hasLoginOnce      = true;
         defaultLoginIndex = -1;
+        loginAttemptState = LoginAttemptState.None;
         manualWorldID     = 0;
         manualCharaIndex  = -1;
     }
+
+    private bool IsDefaultLoginFlow =>
+        manualWorldID == 0 && manualCharaIndex == -1;
 
     private void Swap(int index1, int index2)
     {
@@ -466,10 +524,19 @@ public unsafe class AutoLogin : ModuleBase
         Once,
         Repeat
     }
+
+    private enum LoginAttemptState
+    {
+        None,
+        Waiting,
+        CharaSelectLeft,
+        Failed
+    }
     
     #region 常量
 
     private const string COMMAND = "/pdrlogin";
+    private const int    LoginAttemptNoProgressTimeoutMS = 5_000;
 
     private static readonly Dictionary<BehaviourMode, string> BehaviourModeLoc = new()
     {

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -32,7 +32,7 @@ public unsafe class AutoLogin : ModuleBase
 
     private readonly WorldSelectCombo worldSelectCombo = new("World");
 
-    private int selectedCharaIndex;
+    private string selectedCharaName = string.Empty;
     private int dropIndex = -1;
 
     private bool              hasLoginOnce;
@@ -40,7 +40,7 @@ public unsafe class AutoLogin : ModuleBase
     private LoginAttemptState loginAttemptState;
     private long              loginAttemptStartTicks;
     private ushort            manualWorldID;
-    private int               manualCharaIndex = -1;
+    private string            manualCharaName = string.Empty;
 
     protected override void Init()
     {
@@ -115,15 +115,17 @@ public unsafe class AutoLogin : ModuleBase
                                 worldSelectCombo.SelectedID = world.RowId;
                         }
 
-                        // 角色登录索引选择
+                        // 角色名选择
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted($"{Lang.Get("AutoLogin-CharacterIndex")}:");
+                        ImGui.TextUnformatted("角色名:");
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200f * GlobalUIScale);
-                        ImGui.InputInt("##AutoLogin-EnterCharaIndex", ref selectedCharaIndex);
-                        selectedCharaIndex = Math.Clamp(selectedCharaIndex, 0, 7);
-                        ImGuiOm.TooltipHover(Lang.Get("AutoLogin-CharaIndexInputTooltip"));
+                        ImGui.InputText("##AutoLogin-EnterCharaName", ref selectedCharaName, 32);
+
+                        ImGui.SameLine();
+                        if (ImGui.SmallButton("当前角色") && DService.Instance().ObjectTable.LocalPlayer is { } localPlayer)
+                            selectedCharaName = localPlayer.Name.ToString();
                     }
 
                     ImGui.SameLine();
@@ -133,8 +135,9 @@ public unsafe class AutoLogin : ModuleBase
 
                     if (ImGuiOm.ButtonIconWithTextVertical(FontAwesomeIcon.Plus, Lang.Get("Add")))
                     {
-                        if (selectedCharaIndex is < 0 or > 7 || worldSelectCombo.SelectedID == 0) return;
-                        var info = new LoginInfo(worldSelectCombo.SelectedID, selectedCharaIndex);
+                        var charaName = selectedCharaName.Trim();
+                        if (string.IsNullOrWhiteSpace(charaName) || worldSelectCombo.SelectedID == 0) return;
+                        var info = new LoginInfo(worldSelectCombo.SelectedID, charaName);
 
                         if (!config.LoginInfos.Contains(info))
                         {
@@ -159,7 +162,7 @@ public unsafe class AutoLogin : ModuleBase
                         {
                             ImGui.Selectable
                             (
-                                $"{i + 1}. {Lang.Get("AutoLogin-LoginInfoDisplayText", world.Name.ToString(), world.DataCenter.Value.Name.ToString(), info.CharaIndex)}"
+                                $"{i + 1}. {world.Name} ({world.DataCenter.Value.Name}) - {info.CharaName}"
                             );
                         }
 
@@ -173,13 +176,7 @@ public unsafe class AutoLogin : ModuleBase
                                 ImGui.TextColored
                                 (
                                     ImGuiColors.DalamudYellow,
-                                    Lang.Get
-                                    (
-                                        "AutoLogin-LoginInfoDisplayText",
-                                        world.Name.ToString(),
-                                        world.DataCenter.Value.Name.ToString(),
-                                        info.CharaIndex
-                                    )
+                                    $"{world.Name} ({world.DataCenter.Value.Name}) - {info.CharaName}"
                                 );
                             }
                         }
@@ -270,15 +267,15 @@ public unsafe class AutoLogin : ModuleBase
         if (string.IsNullOrWhiteSpace(args) || !DService.Instance().ClientState.IsLoggedIn || DService.Instance().Condition.IsBoundByDuty)
             return;
 
-        var parts = args.Split(' ');
+        var parts = args.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         switch (parts.Length)
         {
             case 1:
-                if (!int.TryParse(args, out var charaIndex0) || charaIndex0 < 0 || charaIndex0 > 8) return;
+                if (string.IsNullOrWhiteSpace(parts[0])) return;
 
                 manualWorldID    = (ushort)GameState.HomeWorld;
-                manualCharaIndex = charaIndex0;
+                manualCharaName  = parts[0];
                 break;
             case 2:
                 var world1 = Sheets.Worlds.Where(x => x.Value.Name.ToString().Contains(parts[0]))
@@ -287,10 +284,10 @@ public unsafe class AutoLogin : ModuleBase
                                    .Key;
                 if (world1 == 0) return;
 
-                if (!int.TryParse(parts[1], out var charaIndex1) || charaIndex1 < 0 || charaIndex1 > 8) return;
+                if (string.IsNullOrWhiteSpace(parts[1])) return;
 
                 manualWorldID    = (ushort)world1;
-                manualCharaIndex = charaIndex1;
+                manualCharaName  = parts[1];
                 break;
             default:
                 return;
@@ -321,8 +318,8 @@ public unsafe class AutoLogin : ModuleBase
             }
         );
 
-        if (manualWorldID != 0 && manualCharaIndex != -1)
-            TaskHelper.Enqueue(() => SelectCharacter(manualWorldID, manualCharaIndex), "SelectCharaManual");
+        if (manualWorldID != 0 && !string.IsNullOrWhiteSpace(manualCharaName))
+            TaskHelper.Enqueue(() => SelectCharacter(manualWorldID, manualCharaName), "SelectCharaManual");
         else
             TaskHelper.Enqueue(SelectCharacterDefault, "SelectCharaDefault0");
     }
@@ -365,12 +362,12 @@ public unsafe class AutoLogin : ModuleBase
         defaultLoginIndex++;
         TaskHelper.Enqueue
         (
-            () => SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaIndex),
-            $"选择默认角色_{loginInfo.WorldID}_{loginInfo.CharaIndex}"
+            () => SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaName),
+            $"选择默认角色_{loginInfo.WorldID}_{loginInfo.CharaName}"
         );
     }
 
-    private bool SelectCharacter(ushort worldID, int charaIndex)
+    private bool SelectCharacter(ushort worldID, string charaName)
     {
         if (TaskHelper.AbortByConflictKey(this)) return true;
         if (!Throttler.Shared.Throttle("AutoLogin-SelectCharacter", 100)) return false;
@@ -385,11 +382,18 @@ public unsafe class AutoLogin : ModuleBase
         if (agent->WorldId != worldID)
         {
             TaskHelper.Enqueue(() => SelectWorld(worldID),                 "重新选择世界", weight: 2);
-            TaskHelper.Enqueue(() => SelectCharacter(worldID, charaIndex), "重新选择角色");
+            TaskHelper.Enqueue(() => SelectCharacter(worldID, charaName),  "重新选择角色");
             return true;
         }
 
-        AgentLobbyEvent.SelectCharacterByIndex((uint)charaIndex);
+        if (!AgentLobbyEvent.SelectCharacter(entry => IsCharacterMatched(entry, worldID, charaName)))
+        {
+            if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
+                EnqueueNextDefaultCharacter();
+
+            return true;
+        }
+
         if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
         {
             loginAttemptState      = LoginAttemptState.Waiting;
@@ -397,7 +401,7 @@ public unsafe class AutoLogin : ModuleBase
             TaskHelper.Enqueue
             (
                 WaitForLoginAttemptResult,
-                $"WaitLoginAttemptResult_{worldID}_{charaIndex}",
+                $"WaitLoginAttemptResult_{worldID}_{charaName}",
                 timeoutAction: EnqueueNextDefaultCharacter
             );
         }
@@ -434,6 +438,10 @@ public unsafe class AutoLogin : ModuleBase
         return true;
     }
 
+    private static bool IsCharacterMatched(CharaSelectCharacterEntry entry, ushort worldID, string charaName) =>
+        (entry.CurrentWorldId == worldID || entry.HomeWorldId == worldID) &&
+        string.Equals(entry.NameString, charaName.Trim(), StringComparison.OrdinalIgnoreCase);
+
     private bool SelectWorld(ushort worldID)
     {
         if (TaskHelper.AbortByConflictKey(this)) return true;
@@ -459,11 +467,11 @@ public unsafe class AutoLogin : ModuleBase
         defaultLoginIndex = -1;
         loginAttemptState = LoginAttemptState.None;
         manualWorldID     = 0;
-        manualCharaIndex  = -1;
+        manualCharaName   = string.Empty;
     }
 
     private bool IsDefaultLoginFlow =>
-        manualWorldID == 0 && manualCharaIndex == -1;
+        manualWorldID == 0 && string.IsNullOrWhiteSpace(manualCharaName);
 
     private void Swap(int index1, int index2)
     {
@@ -489,25 +497,26 @@ public unsafe class AutoLogin : ModuleBase
     private class LoginInfo
     (
         uint worldID,
-        int  index
+        string charaName
     ) : IEquatable<LoginInfo>
     {
-        public uint WorldID    { get; set; } = worldID;
-        public int  CharaIndex { get; set; } = index;
+        public uint   WorldID   { get; set; } = worldID;
+        public string CharaName { get; set; } = charaName;
 
         public bool Equals(LoginInfo? other)
         {
             if (other is null || GetType() != other.GetType())
                 return false;
 
-            return WorldID == other.WorldID && CharaIndex == other.CharaIndex;
+            return WorldID == other.WorldID &&
+                   string.Equals(CharaName, other.CharaName, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj) =>
             Equals(obj as LoginInfo);
 
         public override int GetHashCode() =>
-            HashCode.Combine(WorldID, CharaIndex);
+            HashCode.Combine(WorldID, StringComparer.OrdinalIgnoreCase.GetHashCode(CharaName));
 
         public static bool operator ==(LoginInfo? lhs, LoginInfo? rhs)
         {

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -116,14 +116,14 @@ public unsafe class AutoLogin : ModuleBase
 
                         // 角色名选择
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted($"{Lang.Get("Name")}:");
+                        ImGui.TextUnformatted($"{Lang.Get("AutoLogin-CharacterName")}:");
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200f * GlobalUIScale);
                         ImGui.InputText("##AutoLogin-EnterCharaName", ref selectedCharaName, 32);
 
                         ImGui.SameLine();
-                        if (ImGui.SmallButton(Lang.Get("Current")) &&
+                        if (ImGui.SmallButton(Lang.Get("AutoLogin-CurrentCharacter")) &&
                             DService.Instance().ObjectTable.LocalPlayer is { } localPlayer)
                             selectedCharaName = localPlayer.Name.ToString();
                     }
@@ -534,7 +534,13 @@ public unsafe class AutoLogin : ModuleBase
                   world.DataCenter.Value.Name.ToString(),
                   info.CharaIndex
               )
-            : $"{LuminaWrapper.GetAddonText(15834)}: {world.Name} ({world.DataCenter.Value.Name}) / {Lang.Get("Name")}: {info.CharaName}";
+            : Lang.Get
+              (
+                  "AutoLogin-LoginInfoNameDisplayText",
+                  world.Name.ToString(),
+                  world.DataCenter.Value.Name.ToString(),
+                  info.CharaName
+              );
 
     private void Swap(int index1, int index2)
     {

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -37,9 +37,8 @@ public unsafe class AutoLogin : ModuleBase
 
     private bool              hasLoginOnce;
     private int               defaultLoginIndex = -1;
-    private LoginAttemptState loginAttemptState;
-    private long              loginAttemptStartTicks;
     private ushort            manualWorldID;
+    private int               manualCharaIndex = -1;
     private string            manualCharaName = string.Empty;
 
     protected override void Init()
@@ -54,7 +53,7 @@ public unsafe class AutoLogin : ModuleBase
         CommandManager.Instance().AddCommand(COMMAND, new(OnCommand) { HelpMessage = Lang.Get("AutoLogin-CommandHelp") });
         DService.Instance().ClientState.Login += OnLogin;
     }
-    
+
     protected override void Uninit()
     {
         DService.Instance().ClientState.Login -= OnLogin;
@@ -163,7 +162,7 @@ public unsafe class AutoLogin : ModuleBase
                         {
                             ImGui.Selectable
                             (
-                                $"{i + 1}. {Lang.Get("AutoLogin-LoginInfoNameDisplayText", world.Name.ToString(), world.DataCenter.Value.Name.ToString(), info.CharaName)}"
+                                $"{i + 1}. {GetLoginInfoDisplayText(world, info)}"
                             );
                         }
 
@@ -177,13 +176,7 @@ public unsafe class AutoLogin : ModuleBase
                                 ImGui.TextColored
                                 (
                                     ImGuiColors.DalamudYellow,
-                                    Lang.Get
-                                    (
-                                        "AutoLogin-LoginInfoNameDisplayText",
-                                        world.Name.ToString(),
-                                        world.DataCenter.Value.Name.ToString(),
-                                        info.CharaName
-                                    )
+                                    GetLoginInfoDisplayText(world, info)
                                 );
                             }
                         }
@@ -281,8 +274,8 @@ public unsafe class AutoLogin : ModuleBase
             case 1:
                 if (string.IsNullOrWhiteSpace(parts[0])) return;
 
-                manualWorldID    = (ushort)GameState.HomeWorld;
-                manualCharaName  = parts[0];
+                if (!TrySetManualCharacter(parts[0])) return;
+                manualWorldID = (ushort)GameState.HomeWorld;
                 break;
             case 2:
                 var world1 = Sheets.Worlds.Where(x => x.Value.Name.ToString().Contains(parts[0]))
@@ -293,8 +286,8 @@ public unsafe class AutoLogin : ModuleBase
 
                 if (string.IsNullOrWhiteSpace(parts[1])) return;
 
-                manualWorldID    = (ushort)world1;
-                manualCharaName  = parts[1];
+                if (!TrySetManualCharacter(parts[1])) return;
+                manualWorldID = (ushort)world1;
                 break;
             default:
                 return;
@@ -325,8 +318,14 @@ public unsafe class AutoLogin : ModuleBase
             }
         );
 
-        if (manualWorldID != 0 && !string.IsNullOrWhiteSpace(manualCharaName))
-            TaskHelper.Enqueue(() => SelectCharacter(manualWorldID, manualCharaName), "SelectCharaManual");
+        if (manualWorldID != 0 && (manualCharaIndex != -1 || !string.IsNullOrWhiteSpace(manualCharaName)))
+            TaskHelper.Enqueue
+            (
+                () => string.IsNullOrWhiteSpace(manualCharaName)
+                          ? SelectCharacter(manualWorldID, manualCharaIndex)
+                          : SelectCharacter(manualWorldID, manualCharaName),
+                "SelectCharaManual"
+            );
         else
             TaskHelper.Enqueue(SelectCharacterDefault, "SelectCharaDefault0");
     }
@@ -340,9 +339,6 @@ public unsafe class AutoLogin : ModuleBase
         if (buttonNode == null) return;
 
         buttonNode->Click();
-
-        if (IsDefaultLoginFlow && loginAttemptState != LoginAttemptState.None)
-            loginAttemptState = LoginAttemptState.Failed;
     }
 
     private void SelectCharacterDefault()
@@ -351,11 +347,25 @@ public unsafe class AutoLogin : ModuleBase
         EnqueueNextDefaultCharacter();
     }
 
+    private bool TrySetManualCharacter(string chara)
+    {
+        if (int.TryParse(chara, out var charaIndex))
+        {
+            if (charaIndex is < 0 or > 8) return false;
+
+            manualCharaIndex = charaIndex;
+            manualCharaName  = string.Empty;
+            return true;
+        }
+
+        manualCharaIndex = -1;
+        manualCharaName  = chara;
+        return true;
+    }
+
     private void EnqueueNextDefaultCharacter()
     {
         if (config.LoginInfos.Count == 0) return;
-
-        loginAttemptState = LoginAttemptState.None;
 
         if (defaultLoginIndex < 0) return;
 
@@ -369,9 +379,49 @@ public unsafe class AutoLogin : ModuleBase
         defaultLoginIndex++;
         TaskHelper.Enqueue
         (
-            () => SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaName),
-            $"选择默认角色_{loginInfo.WorldID}_{loginInfo.CharaName}"
+            () => SelectCharacter(loginInfo),
+            $"选择默认角色_{loginInfo.WorldID}_{loginInfo.DisplayName}"
         );
+    }
+
+    private bool SelectCharacter(LoginInfo loginInfo)
+    {
+        if (!string.IsNullOrWhiteSpace(loginInfo.CharaName))
+            return SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaName);
+
+        if (loginInfo.CharaIndex is < 0 or > 8)
+        {
+            if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
+                EnqueueNextDefaultCharacter();
+
+            return true;
+        }
+
+        return SelectCharacter((ushort)loginInfo.WorldID, loginInfo.CharaIndex);
+    }
+
+    private bool SelectCharacter(ushort worldID, int charaIndex)
+    {
+        if (TaskHelper.AbortByConflictKey(this)) return true;
+        if (!Throttler.Shared.Throttle("AutoLogin-SelectCharacter", 100)) return false;
+
+        var agent = AgentLobby.Instance();
+        if (agent == null) return false;
+
+        var addon = CharaSelectListMenu;
+        if (!addon->IsAddonAndNodesReady()) return false;
+
+        // 不对应, 重新选
+        if (agent->WorldId != worldID)
+        {
+            TaskHelper.Enqueue(() => SelectWorld(worldID),                 "重新选择世界", weight: 2);
+            TaskHelper.Enqueue(() => SelectCharacter(worldID, charaIndex), "重新选择角色");
+            return true;
+        }
+
+        AgentLobbyEvent.SelectCharacterByIndex((uint)charaIndex);
+        EnqueueLoginAttemptResultWait($"WaitLoginAttemptResult_{worldID}_{charaIndex}");
+        return true;
     }
 
     private bool SelectCharacter(ushort worldID, string charaName)
@@ -401,48 +451,43 @@ public unsafe class AutoLogin : ModuleBase
             return true;
         }
 
-        if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
-        {
-            loginAttemptState      = LoginAttemptState.Waiting;
-            loginAttemptStartTicks = Environment.TickCount64;
-            TaskHelper.Enqueue
-            (
-                WaitForLoginAttemptResult,
-                $"WaitLoginAttemptResult_{worldID}_{charaName}",
-                timeoutAction: EnqueueNextDefaultCharacter
-            );
-        }
-
+        EnqueueLoginAttemptResultWait($"WaitLoginAttemptResult_{worldID}_{charaName}");
         return true;
     }
 
-    private bool WaitForLoginAttemptResult()
+    private void EnqueueLoginAttemptResultWait(string taskName)
+    {
+        if (config.Mode == BehaviourMode.Repeat && IsDefaultLoginFlow)
+        {
+            var startTicks = Environment.TickCount64;
+            var hasLeftCharaSelect = new[] { false };
+            TaskHelper.Enqueue
+            (
+                () => WaitForLoginAttemptResult(startTicks, hasLeftCharaSelect),
+                taskName,
+                timeoutAction: EnqueueNextDefaultCharacter
+            );
+        }
+    }
+
+    private bool WaitForLoginAttemptResult(long startTicks, bool[] hasLeftCharaSelect)
     {
         if (DService.Instance().ClientState.IsLoggedIn) return true;
 
-        if (loginAttemptState == LoginAttemptState.Failed)
-        {
-            EnqueueNextDefaultCharacter();
-            return true;
-        }
-
         if (!CharaSelectListMenu->IsAddonAndNodesReady())
         {
-            loginAttemptState = LoginAttemptState.CharaSelectLeft;
+            hasLeftCharaSelect[0] = true;
             return false;
         }
 
-        if (loginAttemptState == LoginAttemptState.Waiting &&
-            Environment.TickCount64 - loginAttemptStartTicks >= LoginAttemptNoProgressTimeoutMS)
+        if (hasLeftCharaSelect[0] ||
+            Environment.TickCount64 - startTicks >= LoginAttemptNoProgressTimeoutMS)
         {
             EnqueueNextDefaultCharacter();
             return true;
         }
 
-        if (loginAttemptState != LoginAttemptState.CharaSelectLeft) return false;
-
-        EnqueueNextDefaultCharacter();
-        return true;
+        return false;
     }
 
     private static bool IsCharacterMatched(CharaSelectCharacterEntry entry, ushort worldID, string charaName) =>
@@ -472,13 +517,30 @@ public unsafe class AutoLogin : ModuleBase
     {
         hasLoginOnce      = true;
         defaultLoginIndex = -1;
-        loginAttemptState = LoginAttemptState.None;
         manualWorldID     = 0;
+        manualCharaIndex  = -1;
         manualCharaName   = string.Empty;
     }
 
     private bool IsDefaultLoginFlow =>
-        manualWorldID == 0 && string.IsNullOrWhiteSpace(manualCharaName);
+        manualWorldID == 0 && manualCharaIndex == -1 && string.IsNullOrWhiteSpace(manualCharaName);
+
+    private static string GetLoginInfoDisplayText(World world, LoginInfo info) =>
+        string.IsNullOrWhiteSpace(info.CharaName)
+            ? Lang.Get
+              (
+                  "AutoLogin-LoginInfoDisplayText",
+                  world.Name.ToString(),
+                  world.DataCenter.Value.Name.ToString(),
+                  info.CharaIndex
+              )
+            : Lang.Get
+              (
+                  "AutoLogin-LoginInfoNameDisplayText",
+                  world.Name.ToString(),
+                  world.DataCenter.Value.Name.ToString(),
+                  info.CharaName
+              );
 
     private void Swap(int index1, int index2)
     {
@@ -501,29 +563,54 @@ public unsafe class AutoLogin : ModuleBase
         public BehaviourMode   Mode       = BehaviourMode.Once;
     }
 
-    private class LoginInfo
-    (
-        uint worldID,
-        string charaName
-    ) : IEquatable<LoginInfo>
+    private class LoginInfo : IEquatable<LoginInfo>
     {
-        public uint   WorldID   { get; set; } = worldID;
-        public string CharaName { get; set; } = charaName;
+        public uint   WorldID    { get; set; }
+        public int    CharaIndex { get; set; } = -1;
+        public string CharaName  { get; set; } = string.Empty;
+
+        public LoginInfo()
+        {
+        }
+
+        public LoginInfo(uint worldID, string charaName)
+        {
+            WorldID   = worldID;
+            CharaName = charaName.Trim();
+        }
+
+        public LoginInfo(uint worldID, int charaIndex)
+        {
+            WorldID    = worldID;
+            CharaIndex = charaIndex;
+        }
+
+        public string DisplayName =>
+            string.IsNullOrWhiteSpace(CharaName) ? CharaIndex.ToString() : CharaName;
 
         public bool Equals(LoginInfo? other)
         {
             if (other is null || GetType() != other.GetType())
                 return false;
 
-            return WorldID == other.WorldID &&
-                   string.Equals(CharaName, other.CharaName, StringComparison.OrdinalIgnoreCase);
+            if (WorldID != other.WorldID) return false;
+
+            return string.IsNullOrWhiteSpace(CharaName) && string.IsNullOrWhiteSpace(other.CharaName)
+                       ? CharaIndex == other.CharaIndex
+                       : string.Equals(CharaName, other.CharaName, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj) =>
             Equals(obj as LoginInfo);
 
         public override int GetHashCode() =>
-            HashCode.Combine(WorldID, StringComparer.OrdinalIgnoreCase.GetHashCode(CharaName));
+            HashCode.Combine
+            (
+                WorldID,
+                string.IsNullOrWhiteSpace(CharaName)
+                    ? CharaIndex
+                    : StringComparer.OrdinalIgnoreCase.GetHashCode(CharaName)
+            );
 
         public static bool operator ==(LoginInfo? lhs, LoginInfo? rhs)
         {
@@ -541,14 +628,6 @@ public unsafe class AutoLogin : ModuleBase
         Repeat
     }
 
-    private enum LoginAttemptState
-    {
-        None,
-        Waiting,
-        CharaSelectLeft,
-        Failed
-    }
-    
     #region 常量
 
     private const string COMMAND = "/pdrlogin";

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -117,14 +117,15 @@ public unsafe class AutoLogin : ModuleBase
 
                         // 角色名选择
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted("角色名:");
+                        ImGui.TextUnformatted($"{Lang.Get("AutoLogin-CharacterName")}:");
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200f * GlobalUIScale);
                         ImGui.InputText("##AutoLogin-EnterCharaName", ref selectedCharaName, 32);
 
                         ImGui.SameLine();
-                        if (ImGui.SmallButton("当前角色") && DService.Instance().ObjectTable.LocalPlayer is { } localPlayer)
+                        if (ImGui.SmallButton(Lang.Get("AutoLogin-CurrentCharacter")) &&
+                            DService.Instance().ObjectTable.LocalPlayer is { } localPlayer)
                             selectedCharaName = localPlayer.Name.ToString();
                     }
 
@@ -162,7 +163,7 @@ public unsafe class AutoLogin : ModuleBase
                         {
                             ImGui.Selectable
                             (
-                                $"{i + 1}. {world.Name} ({world.DataCenter.Value.Name}) - {info.CharaName}"
+                                $"{i + 1}. {Lang.Get("AutoLogin-LoginInfoNameDisplayText", world.Name.ToString(), world.DataCenter.Value.Name.ToString(), info.CharaName)}"
                             );
                         }
 
@@ -176,7 +177,13 @@ public unsafe class AutoLogin : ModuleBase
                                 ImGui.TextColored
                                 (
                                     ImGuiColors.DalamudYellow,
-                                    $"{world.Name} ({world.DataCenter.Value.Name}) - {info.CharaName}"
+                                    Lang.Get
+                                    (
+                                        "AutoLogin-LoginInfoNameDisplayText",
+                                        world.Name.ToString(),
+                                        world.DataCenter.Value.Name.ToString(),
+                                        info.CharaName
+                                    )
                                 );
                             }
                         }

--- a/General/AutoLogin.cs
+++ b/General/AutoLogin.cs
@@ -116,14 +116,14 @@ public unsafe class AutoLogin : ModuleBase
 
                         // 角色名选择
                         ImGui.AlignTextToFramePadding();
-                        ImGui.TextUnformatted($"{Lang.Get("AutoLogin-CharacterName")}:");
+                        ImGui.TextUnformatted($"{Lang.Get("Name")}:");
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200f * GlobalUIScale);
                         ImGui.InputText("##AutoLogin-EnterCharaName", ref selectedCharaName, 32);
 
                         ImGui.SameLine();
-                        if (ImGui.SmallButton(Lang.Get("AutoLogin-CurrentCharacter")) &&
+                        if (ImGui.SmallButton(Lang.Get("Current")) &&
                             DService.Instance().ObjectTable.LocalPlayer is { } localPlayer)
                             selectedCharaName = localPlayer.Name.ToString();
                     }
@@ -438,8 +438,8 @@ public unsafe class AutoLogin : ModuleBase
         // 不对应, 重新选
         if (agent->WorldId != worldID)
         {
-            TaskHelper.Enqueue(() => SelectWorld(worldID),                 "重新选择世界", weight: 2);
-            TaskHelper.Enqueue(() => SelectCharacter(worldID, charaName),  "重新选择角色");
+            TaskHelper.Enqueue(() => SelectWorld(worldID),                "重新选择世界", weight: 2);
+            TaskHelper.Enqueue(() => SelectCharacter(worldID, charaName), "重新选择角色");
             return true;
         }
 
@@ -534,13 +534,7 @@ public unsafe class AutoLogin : ModuleBase
                   world.DataCenter.Value.Name.ToString(),
                   info.CharaIndex
               )
-            : Lang.Get
-              (
-                  "AutoLogin-LoginInfoNameDisplayText",
-                  world.Name.ToString(),
-                  world.DataCenter.Value.Name.ToString(),
-                  info.CharaName
-              );
+            : $"{LuminaWrapper.GetAddonText(15834)}: {world.Name} ({world.DataCenter.Value.Name}) / {Lang.Get("Name")}: {info.CharaName}";
 
     private void Swap(int index1, int index2)
     {


### PR DESCRIPTION
## 变更内容

修复 `AutoLogin` 模块在重复登录模式下的登录尝试逻辑。

现在当用户配置了多个待登录角色时，模块会按照配置列表顺序依次尝试登录，直到登录成功。

## 具体调整

- 修复重复登录模式下只尝试第一个角色的问题。现在当角色选择停留无进展时，会自动切换到下一个配置项
- 将登录配置从角色索引改为角色名匹配

## 说明

角色匹配现在基于 `WorldID + CharacterName`，不再依赖角色列表索引，避免同服务器/多服务器角色顺序变化时登录到错误角色或卡在错误服务器。
