### PR TITLE
迁移跨大区招募 API v2

### DIFF
--- a/Recruitment/CrossDCPartyFinder.cs
+++ b/Recruitment/CrossDCPartyFinder.cs
@@ -586,7 +586,7 @@ public class CrossDCPartyFinder : ModuleBase
     {
         public uint       Page          { get; set; } = 1;
         public uint       PageSize      { get; set; } = 100;
-        public uint?      Category      { get; set; }
+        public DutyCategory? Category   { get; set; }
         public string     World         { get; set; } = string.Empty;
         public string     DataCenter    { get; set; } = string.Empty;
         public List<uint> Jobs          { get; set; } = [];
@@ -629,7 +629,7 @@ public class CrossDCPartyFinder : ModuleBase
                 builder.Append($"&per_page={PageSize}");
 
             if (Category != null)
-                builder.Append($"&category_id={Category.Value}");
+                builder.Append($"&category_id={(uint)Category.Value}");
 
             if (World != string.Empty)
                 builder.Append($"&created_world_id={World}");
@@ -649,69 +649,69 @@ public class CrossDCPartyFinder : ModuleBase
             return $"{BASE_URL}{builder}";
         }
 
-        public static unsafe uint? ParseCategory(AgentLookingForGroup* agent) =>
+        public static unsafe DutyCategory? ParseCategory(AgentLookingForGroup* agent) =>
             agent->CategoryTab switch
             {
-                1  => 2,
-                2  => 4,
-                3  => 8,
-                4  => 16,
-                5  => 32,
-                6  => 64,
-                7  => 128,
-                8  => 256,
-                9  => 512,
-                10 => 1024,
-                11 => 2048,
-                12 => 4096,
-                13 => 8192,
-                14 => 16384,
-                15 => 32768,
-                16 => 0,
+                1  => DutyCategory.Roulette,
+                2  => DutyCategory.Dungeons,
+                3  => DutyCategory.GuildQuests,
+                4  => DutyCategory.Trials,
+                5  => DutyCategory.Raids,
+                6  => DutyCategory.HighEndDuty,
+                7  => DutyCategory.PvP,
+                8  => DutyCategory.GoldSaucer,
+                9  => DutyCategory.FATEs,
+                10 => DutyCategory.TreasureHunts,
+                11 => DutyCategory.TheHunt,
+                12 => DutyCategory.GatheringForays,
+                13 => DutyCategory.DeepDungeons,
+                14 => DutyCategory.FieldOperations,
+                15 => DutyCategory.VCDungeonFinder,
+                16 => DutyCategory.None,
                 _  => null
             };
 
-        public static string ParseCategoryIDToLoc(uint categoryID) =>
+        public static string ParseCategoryIDToLoc(DutyCategory categoryID) =>
             categoryID switch
             {
-                2    => LuminaWrapper.GetAddonText(8605),
-                4    => LuminaWrapper.GetAddonText(8607),
-                8    => LuminaWrapper.GetAddonText(8606),
-                16   => LuminaWrapper.GetAddonText(8608),
-                32   => LuminaWrapper.GetAddonText(8609),
-                64   => LuminaWrapper.GetAddonText(10822),
-                128  => LuminaWrapper.GetAddonText(8610),
-                256  => LuminaWrapper.GetAddonText(8612),
-                512  => LuminaWrapper.GetAddonText(8601),
-                1024 => LuminaWrapper.GetAddonText(8107),
-                2048 => LuminaWrapper.GetAddonText(8613),
-                4096 => LuminaWrapper.GetAddonText(2306),
-                8192 => LuminaWrapper.GetAddonText(2304),
-                16384 => LuminaWrapper.GetAddonText(2307),
-                32768 => LuminaGetter.GetRowOrDefault<ContentType>(30).Name.ToString(),
-                0     => LuminaWrapper.GetAddonText(7),
-                _     => string.Empty
+                DutyCategory.Roulette        => LuminaWrapper.GetAddonText(8605),
+                DutyCategory.Dungeons        => LuminaWrapper.GetAddonText(8607),
+                DutyCategory.GuildQuests     => LuminaWrapper.GetAddonText(8606),
+                DutyCategory.Trials          => LuminaWrapper.GetAddonText(8608),
+                DutyCategory.Raids           => LuminaWrapper.GetAddonText(8609),
+                DutyCategory.HighEndDuty     => LuminaWrapper.GetAddonText(10822),
+                DutyCategory.PvP             => LuminaWrapper.GetAddonText(8610),
+                DutyCategory.GoldSaucer      => LuminaWrapper.GetAddonText(8612),
+                DutyCategory.FATEs           => LuminaWrapper.GetAddonText(8601),
+                DutyCategory.TreasureHunts   => LuminaWrapper.GetAddonText(8107),
+                DutyCategory.TheHunt         => LuminaWrapper.GetAddonText(8613),
+                DutyCategory.GatheringForays => LuminaWrapper.GetAddonText(2306),
+                DutyCategory.DeepDungeons    => LuminaWrapper.GetAddonText(2304),
+                DutyCategory.FieldOperations => LuminaWrapper.GetAddonText(2307),
+                DutyCategory.VCDungeonFinder => LuminaGetter.GetRowOrDefault<ContentType>(30).Name.ToString(),
+                DutyCategory.None            => LuminaWrapper.GetAddonText(7),
+                _                            => string.Empty
             };
 
-        public static uint ParseCategoryIDToIconID(uint categoryID) =>
+        public static uint ParseCategoryIDToIconID(DutyCategory categoryID) =>
             categoryID switch
             {
-                2    => 61807,
-                4    => 61801,
-                8    => 61803,
-                16   => 61804,
-                32   => 61802,
-                64   => 61832,
-                128  => 61806,
-                256  => 61820,
-                512  => 61809,
-                1024 => 61808,
-                2048 => 61819,
-                4096 => 61815,
-                8192 => 61824,
-                16384 => 61837,
-                32768 => 61846,
-                _     => 0
+                DutyCategory.Roulette        => 61807,
+                DutyCategory.Dungeons        => 61801,
+                DutyCategory.GuildQuests     => 61803,
+                DutyCategory.Trials          => 61804,
+                DutyCategory.Raids           => 61802,
+                DutyCategory.HighEndDuty     => 61832,
+                DutyCategory.PvP             => 61806,
+                DutyCategory.GoldSaucer      => 61820,
+                DutyCategory.FATEs           => 61809,
+                DutyCategory.TreasureHunts   => 61808,
+                DutyCategory.TheHunt         => 61819,
+                DutyCategory.GatheringForays => 61815,
+                DutyCategory.DeepDungeons    => 61824,
+                DutyCategory.FieldOperations => 61837,
+                DutyCategory.VCDungeonFinder => 61846,
+                _                            => 0
             };
 
         public PartyFinderRequest Clone() =>
@@ -779,7 +779,7 @@ public class CrossDCPartyFinder : ModuleBase
             public uint HomeWorldId { get; set; }
 
             [JsonProperty("category_id")]
-            public uint CategoryId { get; set; }
+            public DutyCategory CategoryId { get; set; }
 
             [JsonProperty("duty_id")]
             public uint DutyId { get; set; }

--- a/Recruitment/CrossDCPartyFinder.cs
+++ b/Recruitment/CrossDCPartyFinder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Numerics;
 using System.Text;
 using DailyRoutines.Common.Module.Abstractions;
@@ -482,9 +483,27 @@ public class CrossDCPartyFinder : ModuleBase
             },
             cancelSource.Token
         ).ContinueWith
-        (async _ =>
+        (async t =>
             {
                 isNeedToDisable = false;
+
+                if (t.IsFaulted && t.Exception?.InnerException is PartyFinderApiException)
+                {
+                    listings = listingsDisplay = [];
+                    lastUpdate  = DateTime.MinValue;
+                    lastRequest = new();
+                    await DService.Instance().Framework.RunOnFrameworkThread
+                    (() =>
+                        {
+                            unsafe
+                            {
+                                if (!LookingForGroup->IsAddonAndNodesReady()) return;
+                                LookingForGroup->GetTextNodeById(49)->SetText($"{selectedDataCenter}: 0");
+                            }
+                        }
+                    ).ConfigureAwait(false);
+                    return;
+                }
 
                 NotifyHelper.Instance().NotificationInfo($"获取了 {listingsDisplay.Count} 条招募信息");
 
@@ -565,22 +584,40 @@ public class CrossDCPartyFinder : ModuleBase
 
     private class PartyFinderRequest : IEquatable<PartyFinderRequest>
     {
-        public uint       Page       { get; set; } = 1;
-        public uint       PageSize   { get; set; } = 100;
-        public string     Category   { get; set; } = string.Empty;
-        public string     World      { get; set; } = string.Empty;
-        public string     DataCenter { get; set; } = string.Empty;
-        public List<uint> Jobs       { get; set; } = [];
+        public uint       Page          { get; set; } = 1;
+        public uint       PageSize      { get; set; } = 100;
+        public uint?      Category      { get; set; }
+        public string     World         { get; set; } = string.Empty;
+        public string     DataCenter    { get; set; } = string.Empty;
+        public List<uint> Jobs          { get; set; } = [];
+        public uint       HomeWorldId   { get; set; }
+        public string     Region        { get; set; } = string.Empty;
+        public uint       DutyId        { get; set; }
+        public List<uint> JobIds        { get; set; } = [];
 
         public bool Equals(PartyFinderRequest? other)
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Category == other.Category && World == other.World && DataCenter == other.DataCenter;
+            return Category == other.Category && World == other.World && DataCenter == other.DataCenter &&
+                   HomeWorldId == other.HomeWorldId && Region == other.Region && DutyId == other.DutyId &&
+                   Jobs.SequenceEqual(other.Jobs) && JobIds.SequenceEqual(other.JobIds);
         }
 
-        public async Task<PartyFinderList> Request() =>
-            JsonConvert.DeserializeObject<PartyFinderList>(await HTTPClientHelper.Instance().Get().GetStringAsync(Format())) ?? new();
+        public async Task<PartyFinderList> Request()
+        {
+            var client = HTTPClientHelper.Instance().Get();
+            var response = await client.GetAsync(Format()).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = JsonConvert.DeserializeObject<V2ErrorEnvelope>(content);
+                throw new PartyFinderApiException(response.StatusCode, error?.Error?.Code, error?.Error?.Message);
+            }
+
+            return JsonConvert.DeserializeObject<PartyFinderList>(content) ?? new();
+        }
 
         public string Format()
         {
@@ -591,110 +628,90 @@ public class CrossDCPartyFinder : ModuleBase
             if (PageSize != 20)
                 builder.Append($"&per_page={PageSize}");
 
-            if (Category != string.Empty)
-            {
-                if (Category.Contains(' '))
-                    builder.Append($"&category=\"{Category}\"");
-                else
-                    builder.Append($"&category={Category}");
-            }
+            if (Category != null)
+                builder.Append($"&category_id={Category.Value}");
 
             if (World != string.Empty)
-                builder.Append($"&world={World}");
+                builder.Append($"&created_world_id={World}");
+            if (HomeWorldId != 0)
+                builder.Append($"&home_world_id={HomeWorldId}");
             if (DataCenter != string.Empty)
                 builder.Append($"&datacenter={DataCenter}");
-            if (Jobs.Count != 0)
-                builder.Append($"&jobs=\"{string.Join(",", Jobs)}\"");
+            if (Region != string.Empty)
+                builder.Append($"&region={Region}");
+            if (DutyId != 0)
+                builder.Append($"&duty_id={DutyId}");
+            if (JobIds.Count != 0)
+                builder.Append($"&job_ids={string.Join(",", JobIds)}");
+            else if (Jobs.Count != 0)
+                builder.Append($"&job_ids={string.Join(",", Jobs)}");
 
             return $"{BASE_URL}{builder}";
         }
 
-        public static unsafe string ParseCategory(AgentLookingForGroup* agent) =>
+        public static unsafe uint? ParseCategory(AgentLookingForGroup* agent) =>
             agent->CategoryTab switch
             {
-                1  => "DutyRoulette",
-                2  => "Dungeons",
-                3  => "Guildhests",
-                4  => "Trials",
-                5  => "Raids",
-                6  => "HighEndDuty",
-                7  => "Pvp",
-                8  => "GoldSaucer",
-                9  => "Fates",
-                10 => "TreasureHunt",
-                11 => "TheHunt",
-                12 => "GatheringForays",
-                13 => "DeepDungeons",
-                14 => "FieldOperations",
-                15 => "V&C Dungeon Finder",
-                16 => "None",
-                _  => string.Empty
-            };
-
-        public static uint ParseOnlineCategoryToID(string onlineCategory) =>
-            onlineCategory.Trim() switch
-            {
-                "DutyRoulette"       => 1,
-                "Dungeons"           => 2,
-                "Guildhests"         => 3,
-                "Trials"             => 4,
-                "Raids"              => 5,
-                "HighEndDuty"        => 6,
-                "Pvp"                => 7,
-                "GoldSaucer"         => 8,
-                "Fates"              => 9,
-                "TreasureHunt"       => 10,
-                "TheHunt"            => 11,
-                "GatheringForays"    => 12,
-                "DeepDungeons"       => 13,
-                "DeepDungeon"        => 13,
-                "FieldOperations"    => 14,
-                "V&C Dungeon Finder" => 15,
-                "None"               => 16,
-                _                    => 0
+                1  => 2,
+                2  => 4,
+                3  => 8,
+                4  => 16,
+                5  => 32,
+                6  => 64,
+                7  => 128,
+                8  => 256,
+                9  => 512,
+                10 => 1024,
+                11 => 2048,
+                12 => 4096,
+                13 => 8192,
+                14 => 16384,
+                15 => 32768,
+                16 => 0,
+                _  => null
             };
 
         public static string ParseCategoryIDToLoc(uint categoryID) =>
             categoryID switch
             {
-                1  => LuminaWrapper.GetAddonText(8605),
-                2  => LuminaWrapper.GetAddonText(8607),
-                3  => LuminaWrapper.GetAddonText(8606),
-                4  => LuminaWrapper.GetAddonText(8608),
-                5  => LuminaWrapper.GetAddonText(8609),
-                6  => LuminaWrapper.GetAddonText(10822),
-                7  => LuminaWrapper.GetAddonText(8610),
-                8  => LuminaWrapper.GetAddonText(8612),
-                9  => LuminaWrapper.GetAddonText(8601),
-                10 => LuminaWrapper.GetAddonText(8107),
-                11 => LuminaWrapper.GetAddonText(8613),
-                12 => LuminaWrapper.GetAddonText(2306),
-                13 => LuminaWrapper.GetAddonText(2304),
-                14 => LuminaWrapper.GetAddonText(2307),
-                15 => LuminaGetter.GetRowOrDefault<ContentType>(30).Name.ToString(),
-                16 => LuminaWrapper.GetAddonText(7),
-                _  => string.Empty
+                2    => LuminaWrapper.GetAddonText(8605),
+                4    => LuminaWrapper.GetAddonText(8607),
+                8    => LuminaWrapper.GetAddonText(8606),
+                16   => LuminaWrapper.GetAddonText(8608),
+                32   => LuminaWrapper.GetAddonText(8609),
+                64   => LuminaWrapper.GetAddonText(10822),
+                128  => LuminaWrapper.GetAddonText(8610),
+                256  => LuminaWrapper.GetAddonText(8612),
+                512  => LuminaWrapper.GetAddonText(8601),
+                1024 => LuminaWrapper.GetAddonText(8107),
+                2048 => LuminaWrapper.GetAddonText(8613),
+                4096 => LuminaWrapper.GetAddonText(2306),
+                8192 => LuminaWrapper.GetAddonText(2304),
+                16384 => LuminaWrapper.GetAddonText(2307),
+                32768 => LuminaGetter.GetRowOrDefault<ContentType>(30).Name.ToString(),
+                0     => LuminaWrapper.GetAddonText(7),
+                _     => string.Empty
             };
 
         public static uint ParseCategoryIDToIconID(uint categoryID) =>
             categoryID switch
             {
-                1  => 61807,
-                2  => 61801,
-                3  => 61803,
-                4  => 61804,
-                5  => 61802,
-                6  => 61832,
-                7  => 61806,
-                8  => 61820,
-                9  => 61809,
-                10 => 61808,
-                11 => 61819,
-                12 => 61815,
-                13 => 61824,
-                14 => 61837,
-                15 => 61846,
-                _  => 0
+                2    => 61807,
+                4    => 61801,
+                8    => 61803,
+                16   => 61804,
+                32   => 61802,
+                64   => 61832,
+                128  => 61806,
+                256  => 61820,
+                512  => 61809,
+                1024 => 61808,
+                2048 => 61819,
+                4096 => 61815,
+                8192 => 61824,
+                16384 => 61837,
+                32768 => 61846,
+                _     => 0
             };
 
         public PartyFinderRequest Clone() =>
@@ -705,14 +722,23 @@ public class CrossDCPartyFinder : ModuleBase
                 Category   = Category,
                 World      = World,
                 DataCenter = DataCenter,
-                Jobs       = [..Jobs]
+                Jobs       = [..Jobs],
+                HomeWorldId = HomeWorldId,
+                Region     = Region,
+                DutyId     = DutyId,
+                JobIds     = [..JobIds]
             };
 
         public override bool Equals(object? obj) =>
             obj != null && Equals(obj as PartyFinderRequest);
 
         public override int GetHashCode() =>
-            HashCode.Combine(Category, World, DataCenter, Jobs);
+            HashCode.Combine
+            (
+                Category, World, DataCenter, HomeWorldId, Region, DutyId,
+                Jobs.Aggregate(0, (hash, job) => HashCode.Combine(hash, job)),
+                JobIds.Aggregate(0, (hash, job) => HashCode.Combine(hash, job))
+            );
 
         public static bool operator ==(PartyFinderRequest? left, PartyFinderRequest? right) =>
             Equals(left, right);
@@ -738,55 +764,37 @@ public class CrossDCPartyFinder : ModuleBase
             private Task<string>? detailReuqestTask;
 
             [JsonProperty("id")]
-            public int ID { get; set; }
+            public string ID { get; set; }
 
-            [JsonProperty("name")]
+            [JsonProperty("player_name")]
             public string PlayerName { get; set; }
 
             [JsonProperty("description")]
             public string Description { get; set; }
 
-            [JsonProperty("created_world")]
-            public string CreatedAtWorldName { get; set; }
-
             [JsonProperty("created_world_id")]
-            public string CreatedAtWorld { get; set; }
-
-            [JsonProperty("home_world")]
-            public string HomeWorldName { get; set; }
+            public uint CreatedAtWorldId { get; set; }
 
             [JsonProperty("home_world_id")]
-            public string HomeWorld { get; set; }
-
-            [JsonProperty("datacenter")]
-            public string DataCenter { get; set; }
-
-            [JsonProperty("category")]
-            public string CategoryName { get; set; }
+            public uint HomeWorldId { get; set; }
 
             [JsonProperty("category_id")]
-            public DutyCategory Category { get; set; }
+            public uint CategoryId { get; set; }
 
-            [JsonProperty("duty")]
-            public string Duty { get; set; }
+            [JsonProperty("duty_id")]
+            public uint DutyId { get; set; }
 
             [JsonProperty("min_item_level")]
             public uint MinItemLevel { get; set; }
-
-            [JsonProperty("time_left")]
-            public float TimeLeft { get; set; }
-
-            [JsonProperty("updated_at")]
-            public DateTime UpdatedAt { get; set; }
-
-            [JsonProperty("is_cross_world")]
-            public bool IsCrossWorld { get; set; }
 
             [JsonProperty("slots_filled")]
             public int SlotFilled { get; set; }
 
             [JsonProperty("slots_available")]
             public int SlotAvailable { get; set; }
+
+            [JsonProperty("time_left_seconds")]
+            public float TimeLeft { get; set; }
 
             public PartyFinderListingDetail? Detail { get; set; }
 
@@ -795,9 +803,21 @@ public class CrossDCPartyFinder : ModuleBase
                 get
                 {
                     if (categoryIcon != 0) return categoryIcon;
-                    return categoryIcon = PartyFinderRequest.ParseCategoryIDToIconID(PartyFinderRequest.ParseOnlineCategoryToID(CategoryName));
+                    return categoryIcon = PartyFinderRequest.ParseCategoryIDToIconID(CategoryId);
                 }
             }
+
+            public string CreatedAtWorldName =>
+                LuminaGetter.GetRowOrDefault<World>(CreatedAtWorldId).Name.ToString();
+
+            public string HomeWorldName =>
+                LuminaGetter.GetRowOrDefault<World>(HomeWorldId).Name.ToString();
+
+            public string Duty =>
+                LuminaWrapper.GetContentName(DutyId);
+
+            public string CategoryName =>
+                PartyFinderRequest.ParseCategoryIDToLoc(CategoryId);
 
             public bool Equals(PartyFinderListing? other)
             {
@@ -812,182 +832,141 @@ public class CrossDCPartyFinder : ModuleBase
             {
                 if (Detail != null || detailReuqestTask != null) return;
 
-                detailReuqestTask = HTTPClientHelper.Instance().Get().GetStringAsync($"{BASE_DETAIL_URL}{ID}");
-                Detail            = JsonConvert.DeserializeObject<PartyFinderListingDetail>(await detailReuqestTask.ConfigureAwait(false)) ?? new();
+                detailReuqestTask = RequestContentAsync();
+                Detail            = JsonConvert.DeserializeObject<PartyFinderDetailResponse>(await detailReuqestTask.ConfigureAwait(false))?.Data ?? new();
+
+                async Task<string> RequestContentAsync()
+                {
+                    var client = HTTPClientHelper.Instance().Get();
+                    var response = await client.GetAsync($"{BASE_DETAIL_URL}{ID}").ConfigureAwait(false);
+                    var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var error = JsonConvert.DeserializeObject<V2ErrorEnvelope>(content);
+                        throw new PartyFinderApiException(response.StatusCode, error?.Error?.Code, error?.Error?.Message);
+                    }
+
+                    return content;
+                }
             }
 
             public string GetSearchString() =>
-                $"{PlayerName}_{Description}_{PartyFinderRequest.ParseCategoryIDToLoc(PartyFinderRequest.ParseOnlineCategoryToID(CategoryName))}_{Duty}";
+                $"{PlayerName}_{Description}_{CategoryName}_{Duty}";
         }
 
         public class PartyFinderOverview
         {
             [JsonProperty("total")]
             public uint Total { get; set; }
-
-            [JsonProperty("page")]
-            public uint Page { get; set; }
-
-            [JsonProperty("per_page")]
-            public uint PerPage { get; set; }
-
-            [JsonProperty("total_pages")]
-            public uint TotalPages { get; set; }
         }
+    }
+
+    private class PartyFinderDetailResponse
+    {
+        [JsonProperty("data")]
+        public PartyFinderListingDetail Data { get; set; } = new();
     }
 
     private class PartyFinderListingDetail
     {
-        [JsonProperty("id")]
-        public long ID { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonProperty("created_world")]
-        public string CreatedAtWorld { get; set; }
-
-        [JsonProperty("home_world")]
-        public string HomeWorld { get; set; }
-
-        [JsonProperty("category")]
-        public string Category { get; set; }
-
-        [JsonProperty("duty")]
-        public string Duty { get; set; }
-
-        [JsonProperty("min_item_level")]
-        public int MinItemLevel { get; set; }
-
-        [JsonProperty("slots_filled")]
-        public int SlotsFilled { get; set; }
-
-        [JsonProperty("slots_available")]
-        public int SlotsAvailable { get; set; }
-
-        [JsonProperty("time_left")]
-        public double TimeLeft { get; set; }
-
-        [JsonProperty("updated_at")]
-        public DateTime UpdatedAt { get; set; }
-
-        [JsonProperty("is_cross_world")]
-        public bool IsCrossWorld { get; set; }
-
-        [JsonProperty("beginners_welcome")]
-        public bool BeginnersWelcome { get; set; }
-
-        [JsonProperty("duty_type")]
-        public string DutyType { get; set; }
-
-        [JsonProperty("objective")]
-        public string Objective { get; set; }
-
-        [JsonProperty("conditions")]
-        public string Conditions { get; set; }
-
-        [JsonProperty("loot_rules")]
-        public string LootRules { get; set; }
-
         [JsonProperty("slots")]
         public List<Slot> Slots { get; set; }
 
-        [JsonProperty("datacenter")]
-        public string DataCenter { get; set; }
-
         public class Slot
         {
-            public static readonly HashSet<string> BattleJobs;
-            public static readonly HashSet<string> TankJobs;
-            public static readonly HashSet<string> DPSJobs;
-            public static readonly HashSet<string> HealerJobs;
-
-            static Slot()
-            {
-                BattleJobs = LuminaGetter.Get<ClassJob>()
-                                         .Where(x => x.RowId != 0 && x.DohDolJobIndex == -1)
-                                         .Select(x => x.Abbreviation.ToString())
-                                         .ToHashSet();
-
-                TankJobs = LuminaGetter.Get<ClassJob>()
-                                       .Where(x => x.RowId != 0 && x.Role is 1)
-                                       .Select(x => x.Abbreviation.ToString())
-                                       .ToHashSet();
-
-                DPSJobs = LuminaGetter.Get<ClassJob>()
-                                      .Where(x => x.RowId != 0 && x.Role is 2 or 3)
-                                      .Select(x => x.Abbreviation.ToString())
-                                      .ToHashSet();
-
-                HealerJobs = LuminaGetter.Get<ClassJob>()
-                                         .Where(x => x.RowId != 0 && x.Role is 4)
-                                         .Select(x => x.Abbreviation.ToString())
-                                         .ToHashSet();
-            }
-
             [JsonProperty("filled")]
             public bool Filled { get; set; }
 
-            [JsonProperty("role")]
-            public string? RoleName { get; set; }
-
             [JsonProperty("role_id")]
-            public string? Role { get; set; }
+            public uint RoleId { get; set; }
 
-            [JsonProperty("job")]
-            public string JobName { get; set; }
+            [JsonProperty("filled_job_id")]
+            public uint? FilledJobId { get; set; }
+
+            [JsonProperty("accepted_job_ids")]
+            public List<uint> AcceptedJobIds { get; set; }
+
+            private List<uint>? field;
 
             public List<uint> JobIcons
             {
                 get
                 {
-                    if (string.IsNullOrEmpty(JobName)) return [];
+                    if (field != null) return field;
 
-                    var splited = JobName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    var icons = new List<uint>();
 
-                    if (field.Count == 0)
+                    if (FilledJobId != null)
                     {
-                        if (splited.Length == 1)
-                            field = [ParseClassJobIdByName(JobName)];
-                        // 全战职
-                        else if (splited.Length == BattleJobs.Count && splited.All(BattleJobs.Contains))
-                            field = [62145];
-                        // 坦克
-                        else if (splited.All(TankJobs.Contains))
-                            field = [62571];
-                        // DPS
-                        else if (splited.All(DPSJobs.Contains))
-                            field = [62573];
-                        // 奶妈
-                        else if (splited.All(HealerJobs.Contains))
-                            field = [62572];
+                        icons.Add(62100 + FilledJobId.Value);
+                    }
+                    else if (AcceptedJobIds.Count != 0)
+                    {
+                        var role = RoleId;
+                        if (role == 1)
+                            icons.Add(62571);
+                        else if (role == 2 || role == 3)
+                            icons.Add(62573);
+                        else if (role == 4)
+                            icons.Add(62572);
                         else
                         {
-                            List<uint> icons = [];
-                            splited.ForEach(x => icons.Add(ParseClassJobIdByName(x)));
-                            field = icons.Where(x => x != 0).ToList();
+                            foreach (var jobId in AcceptedJobIds)
+                                icons.Add(62100 + jobId);
                         }
                     }
-
-                    return field;
-
-                    uint ParseClassJobIdByName(string job)
+                    else
                     {
-                        var rowID = LuminaGetter.Get<ClassJob>().FirstOrDefault(x => x.Abbreviation.ToString() == job).RowId;
-                        return rowID == 0 ? 62145 : 62100 + rowID;
+                        icons.Add(62145);
                     }
+
+                    field = icons;
+                    return field;
                 }
-            } = [];
+            }
         }
     }
     
     #region 常量
 
-    private const string BASE_URL        = "https://xivpf.littlenightmare.top/api/listings?";
-    private const string BASE_DETAIL_URL = "https://xivpf.littlenightmare.top/api/listing/";
+    private const string BASE_URL        = "https://xivpf.littlenightmare.top/api/v2/listings?";
+    private const string BASE_DETAIL_URL = "https://xivpf.littlenightmare.top/api/v2/listings/";
+
+    #endregion
+
+    #region v2 Error Handling
+
+    private class V2ErrorEnvelope
+    {
+        [JsonProperty("error")]
+        public V2Error? Error { get; set; }
+    }
+
+    private class V2Error
+    {
+        [JsonProperty("code")]
+        public string? Code { get; set; }
+
+        [JsonProperty("message")]
+        public string? Message { get; set; }
+
+        [JsonProperty("details")]
+        public string? Details { get; set; }
+    }
+
+    private class PartyFinderApiException : Exception
+    {
+        public HttpStatusCode StatusCode { get; }
+        public string? ErrorCode { get; }
+
+        public PartyFinderApiException(HttpStatusCode statusCode, string? errorCode, string? message)
+            : base(message ?? $"API error: {statusCode}")
+        {
+            StatusCode = statusCode;
+            ErrorCode = errorCode;
+        }
+    }
 
     #endregion
 }


### PR DESCRIPTION
## 变更内容

本次主要将“跨大区队员招募”模块使用的 remote-party-finder 接口从 v1 迁移到 v2，并尽量保持原有 UI 行为不变。

### API 迁移

- 列表接口从：

  ```text
  /api/listings
  ```

  迁移到：

  ```text
  /api/v2/listings
  ```

- 详情接口从：

  ```text
  /api/listing/{id}
  ```

  迁移到：

  ```text
  /api/v2/listings/{id}
  ```

- 适配 v2 的响应包装结构：
  - 列表接口使用 `{ data, pagination }`
  - 详情接口使用 `{ data }`
- 招募 ID 按 [v2 文档](https://github.com/LittleNightmare/remote-party-finder/blob/main/docs/api-v2.md)改为 `string` 处理，避免大 ID 精度或范围问题。

### 查询参数调整

根据 v2 API 的字段变化调整请求构造：

- `category` -> `category_id`
- `world` -> `created_world_id`
- `jobs` -> `job_ids`
- `duty` -> `duty_id`
- 保留 `datacenter`
- 预留并支持 v2 的 `home_world_id`、`region`、`duty_id`、`job_ids`

其中原 v1 的 `world` 在当前模块语义中对应招募创建世界，因此迁移为 `created_world_id`，而不是 `home_world_id`。

### 分类处理

v1 中分类使用字符串，例如：

```text
category=HighEndDuty
```

v2 中分类使用 `category_id`，因此将请求侧分类转换从原来的：

```text
游戏内 CategoryTab -> 字符串分类名 -> API 分类 ID
```

调整为：

```text
游戏内 CategoryTab -> v2 category_id
```

并使用 Dalamud `DutyCategory` 对应的 bitflag 值：

- Roulette: `2`
- Dungeons: `4`
- GuildQuests: `8`
- Trials: `16`
- Raids: `32`
- HighEndDuty: `64`
- PvP: `128`
- GoldSaucer: `256`
- FATEs: `512`
- TreasureHunts: `1024`
- TheHunt: `2048`
- GatheringForays: `4096`
- DeepDungeons: `8192`
- FieldOperations: `16384`
- VCDungeonFinder: `32768`
- None: `0`

同时将请求中的分类字段改为 nullable：

```csharp
uint? Category
```

以区分：

- `null`: 不发送分类筛选
- `0`: 明确发送 `category_id=0`，筛选 None 分类

实际接口验证中，`category_id=0` 与省略 `category_id` 返回结果不同，因此这里不能继续把 `0` 当成“不发送”的哨兵值。

### 本地显示字段解析

v2 不再直接返回部分文本字段，因此改为使用 ID 在本地解析显示名：

- `created_world_id` -> 本地世界名
- `home_world_id` -> 本地世界名
- `category_id` -> 本地分类名
- `duty_id` -> 本地任务名

其中 `duty_id` 可能为 `0`，例如 The Hunt、Treasure Hunts 等类型的招募。为避免 UI 绘制时空引用，任务名解析改为使用已有的安全封装：

```csharp
LuminaWrapper.GetContentName(DutyId)
```

查不到时返回空字符串。

### 搜索行为保持

v1 文档中虽然存在远端 `search` 参数，但原模块的搜索框实际是本地二次过滤：

```csharp
GetSearchString().Contains(currentSeach, ...)
```

本次迁移没有把搜索框绑定到 v2 的远端 `search` 参数，避免改变原有搜索语义。

当前仍按以下字段进行本地搜索：

- 玩家名
- 招募描述
- 分类名
- 任务名

### 排序与分页行为

原有排序逻辑保持不变：

- 倒序时按剩余时间从大到小
- 非倒序时按剩余时间从小到大
- 仍然是拉取远端数据后，在本地进行过滤、排序、分页展示

原有去重逻辑也保持原结构：

- 先按 `ID` 去重
- 再按 `PlayerName@HomeWorldName` 去重

相关字段的数据来源从 v1 的文本字段调整为 v2 的 ID 字段本地解析结果。

### 招募详情与职业图标

v2 的详情接口中 slot 字段变为：

- `filled`
- `role_id`
- `filled_job_id`
- `accepted_job_ids`

因此详情解析改为使用这些字段。

同时修复了 v2 下的空值问题：

- `filled_job_id` 在空位时可能为 `null`
- 原先使用 `uint` 会导致 Json.NET 反序列化异常
- 现已改为 `uint?`

职业图标逻辑对应调整为：

- 有 `filled_job_id` 时显示已填充职业图标
- 无 `filled_job_id` 但有 `accepted_job_ids` 时，根据 `role_id` 显示坦克、DPS、治疗聚合图标，或显示具体可接受职业
- 无可接受职业信息时显示全职业图标

### 请求缓存判断

原模块会在短时间内复用上一次请求结果。v2 迁移后，实际影响请求 URL 的字段变多，因此请求相等判断同步纳入这些字段：

- `Category`
- `World`
- `DataCenter`
- `HomeWorldId`
- `Region`
- `DutyId`
- `Jobs`
- `JobIds`

避免不同 v2 查询被错误当作同一个请求，从而复用旧结果。

### 错误处理

v2 错误响应使用结构化 error envelope。本次增加对应处理：

- 非 2xx 响应时解析 v2 错误结构
- 请求失败时清空当前远端招募列表
- 重置更新时间和请求缓存
- 将 UI 计数更新为 `0`

避免接口错误时继续展示旧数据或错误状态数据。

## 测试情况

### 构建验证

已执行：

```powershell
dotnet build DailyRoutines.ModulesPublic\DailyRoutines.ModulesPublic.csproj -p:Platform=x64
```

结果：

- build 通过
- 0 errors
- 仍有既有 warning，本次未处理这些 warning，以避免扩大迁移范围

### API 验证

对 v2 接口做了基础请求验证，包括：

- 列表接口：

  ```text
  /api/v2/listings?per_page=1
  ```

- 详情接口：

  ```text
  /api/v2/listings/{id}
  ```

- 分类筛选：

  ```text
  /api/v2/listings?per_page=1&category_id=0
  /api/v2/listings?per_page=1&category_id=64
  ```

- 职业筛选：

  ```text
  /api/v2/listings?per_page=1&job_ids=24,28
  ```

- 异常请求：
  - 非法查询参数
  - 非法详情 ID
  - 不存在的详情 ID

### 语义验证

通过实际接口返回确认：

- 省略 `category_id` 与 `category_id=0` 语义不同
  - 省略表示不筛选分类
  - `category_id=0` 表示筛选 None 分类
- `filled_job_id` 在空位时可能为 `null`
- `duty_id` 可能为 `0`
- v2 详情接口返回 `{ data: ... }` 包装结构
- v2 列表接口返回 `{ data, pagination }` 包装结构
- `job_ids` 应使用裸 CSV，例如：

  ```text
  job_ids=24,28
  ```

  而不是 v1 风格的带引号写法。

### 游戏内验证情况

已重点关注：

- 跨大区招募列表加载
- 列表基础展示
- 详情请求解析
- 职业图标显示逻辑
- `filled_job_id = null` 时不再抛异常
- `duty_id = 0` 时 UI 不再因任务名解析崩溃
- 本地搜索行为仍保留
- 排序逻辑未刻意调整

### 测试不足

以下内容尚未完整覆盖：

- 未完整测试游戏内“一键占位”相关流程
- 未长时间观察接口失败、刷新、切换大区、切换分类等组合操作下的边界行为
- 未对 v2 API 的所有可选过滤参数做完整组合测试

本次主要验证集中在：

- v2 API 兼容
- 列表和详情解析
- 分类、世界、任务、职业字段迁移
- 搜索 / 排序 / 分页行为尽量保持原样
- 已发现的 UI 崩溃和反序列化异常修复