### PR TITLE
feat: 新增一键试穿玩家全套幻化模块

### DIFF
--- a/UIOperation/AutoTryOnPlayerOutfit.cs
+++ b/UIOperation/AutoTryOnPlayerOutfit.cs
@@ -1,0 +1,177 @@
+using DailyRoutines.Common.Module.Abstractions;
+using DailyRoutines.Common.Module.Enums;
+using DailyRoutines.Common.Module.Models;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using KamiToolKit.Enums;
+using KamiToolKit.Nodes;
+using OmenTools.Threading;
+
+namespace DailyRoutines.ModulesPublic;
+
+public unsafe class AutoTryOnPlayerOutfit : ModuleBase
+{
+    public override ModuleInfo Info { get; } = new()
+    {
+        Title       = Lang.Get("AutoTryOnPlayerOutfitTitle"),
+        Description = Lang.Get("AutoTryOnPlayerOutfitDescription"),
+        Category    = ModuleCategory.UIOperation,
+        Author      = ["ErxCharlotte"]
+    };
+
+    private HorizontalListNode? layoutNode;
+    private TextButtonNode?     tryOnButtonNode;
+
+    // 5是腰带，13 是职业水晶
+    private static readonly int[] TryOnSlots = [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12];
+
+    protected override void Init()
+    {
+        TaskHelper ??= new() { TimeoutMS = 10_000 };
+
+        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PostDraw,    "CharacterInspect", OnAddonList);
+        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PreFinalize, "CharacterInspect", OnAddonList);
+    }
+
+    protected override void Uninit()
+    {
+        DService.Instance().AddonLifecycle.UnregisterListener(OnAddonList);
+        OnAddonList(AddonEvent.PreFinalize, null);
+    }
+
+    private void OnAddonList(AddonEvent type, AddonArgs? args)
+    {
+        switch (type)
+        {
+            case AddonEvent.PostDraw:
+                if (CharacterInspect == null) return;
+
+                //调查页面底部的<设计搭配>按钮 它的ButtonNodeId = 6
+                var designButtonNode = CharacterInspect->GetNodeById(6);
+    
+                tryOnButtonNode ??= new()
+                {
+                    IsVisible = true,
+                    Size      = new(designButtonNode->Width, designButtonNode->Height),
+                };
+
+                if (layoutNode == null)
+                {
+                    layoutNode = new()
+                    {
+                        IsVisible = true,
+                        Size      = new(200, 28),
+                        Position  = new(designButtonNode->X, designButtonNode->Y + designButtonNode->Height),
+                        Alignment = HorizontalListAnchor.Left
+                    };
+
+                    layoutNode.AddNode([tryOnButtonNode]);
+                    layoutNode.AttachNode(CharacterInspect->RootNode);
+                }
+                
+                if (Throttler.Shared.Throttle("AutoTryOnPlayerOutfit-PostDraw"))
+                {
+                    if (TaskHelper.IsBusy)
+                    {
+                        tryOnButtonNode.String  = Lang.Get("Stop");
+                        tryOnButtonNode.OnClick = () => TaskHelper.Abort();
+                    }
+                    else
+                    {
+                        tryOnButtonNode.String  = Lang.Get("AutoTryOnPlayerOutfit-TryOnAll");
+                        tryOnButtonNode.OnClick = StartTryOnAll;
+                    }
+                }
+                break;
+
+            case AddonEvent.PreFinalize:
+                tryOnButtonNode?.Dispose();
+                tryOnButtonNode = null;
+
+                layoutNode?.Dispose();
+                layoutNode = null;
+
+                TaskHelper?.Abort();
+                break;
+        }
+    }
+
+    private void StartTryOnAll()
+    {
+        if (TaskHelper.IsBusy) return;
+        TaskHelper.Enqueue(StartTryOn);
+    }
+
+    private bool StartTryOn()
+    {
+        if (DService.Instance().Condition.IsOccupiedInEvent ||
+            !CharacterInspect->IsAddonAndNodesReady() ||
+            AgentTryon.Instance() == null) 
+            return false;
+
+        //判断当前玩家是否有可以试穿的装备
+        var entries = ReadInspectItems();
+        if (entries == null || entries.Count == 0)
+        {
+            TaskHelper.Abort();
+            return true;
+        }
+
+        //保存试穿内容
+        AgentTryon.Instance()->SaveDeleteOutfit = true;
+
+        //试穿entries中的内容
+        foreach (var entry in entries)
+        {
+            TaskHelper.Enqueue(() =>
+            {
+                //种族/性别导致不能试穿的时候跳过继续下一步
+                AgentTryon.TryOn(0, entry.TryOnItemID, entry.Stain0ID, entry.Stain1ID);
+                return true;
+            });
+            TaskHelper.DelayNext(100);
+        }
+        return true;
+    }
+
+    private static List<TryOnEntry>? ReadInspectItems()
+    {
+        if (!InventoryType.Examine.TryGetItems(
+                x => x.ItemId != 0 && TryOnSlots.Contains(x.Slot),
+                out var items))
+            return null;
+
+        List<TryOnEntry> entries = [];
+
+        foreach (var item in items)
+        {
+            var itemId        = item.ItemId;
+            var glamourItemId = item.GlamourId;
+
+            //有幻化→试穿幻化，无幻化→试穿原装备
+            var tryOnItemId = glamourItemId != 0 ? glamourItemId : itemId;
+
+            if (tryOnItemId == 0) continue;
+
+            entries.Add(new()
+            {
+                Slot        = item.Slot,
+                TryOnItemID = tryOnItemId,
+                Stain0ID    = item.Stains[0],
+                Stain1ID    = item.Stains[1]
+            });
+        }
+
+        return entries;
+    }
+
+    private struct TryOnEntry
+    {
+        public int    Slot;
+        public uint   TryOnItemID;
+        public byte   Stain0ID;
+        public byte   Stain1ID;
+    }
+}


### PR DESCRIPTION
该模块会在调查玩家窗口中添加<试穿全部>按钮，用于一键试穿被调查玩家当前幻化。

- <试穿全部>按钮位于<设计搭配>按钮的下方
- 跳过空装备槽位和因性别/种族导致不能试穿的槽位
- 被调查玩家有幻化的情况会获取其幻化，没有的话则获取原装备
- 按下按钮则自动开始按顺序试穿被调查玩家的所有幻化，包括幻化的双染色
- 按下按钮后可选择暂停

测试：
- 已测试打开玩家调查窗口后按钮正常显示
- 已测试点击“试穿全部”后可以依次试穿目标玩家装备
- 已测试遇到空槽位与因种族/性别无法试穿的装备时，会跳过，后续装备仍会继续试穿
- 已测试关闭调查窗口后按钮会被清理