### PR TITLE
移除 AutoEliminateFishAwareness 无用的自动抛竿选项

### DIFF
--- a/General/AutoEliminateFishAwareness.cs
+++ b/General/AutoEliminateFishAwareness.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
@@ -10,6 +11,7 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using OmenTools.ImGuiOm.Widgets.Combos;
 using OmenTools.Info.Game.Enums;
 using OmenTools.Interop.Game.Helpers;
+using OmenTools.Interop.Game.Lumina;
 using OmenTools.OmenService;
 using OmenTools.Threading;
 
@@ -73,6 +75,10 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
 
         ImGui.NewLine();
 
+        if (ImGui.Checkbox(Lang.Get("AutoEliminateFishAwareness-AutoCast"), ref config.AutoCast))
+            config.Save(this);
+        ImGuiOm.HelpMarker(Lang.Get("AutoEliminateFishAwareness-AutoCastHelp"));
+        
         if (ImGui.Checkbox(Lang.Get("AutoEliminateFishAwareness-LogoutWhenGlobalWarning"), ref config.LogoutWhenGlobalWarning))
             config.Save(this);
     }
@@ -126,8 +132,11 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
                 else
                     return;
 
-                TaskHelper.Enqueue(() => ActionManager.Instance()->GetActionStatus(ActionType.Action, 289) == 0, "等待技能抛竿可用");
-                
+                if (config.AutoCast)
+                    TaskHelper.Enqueue(EnterFishing, "进入钓鱼状态");
+                else
+                    TaskHelper.Enqueue(() => ActionManager.Instance()->GetActionStatus(ActionType.Action, 289) == 0, "等待技能抛竿可用");
+
                 TaskHelper.Enqueue
                 (
                     () =>
@@ -161,8 +170,18 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
         return true;
     }
 
+    private static bool EnterFishing()
+    {
+        if (!Throttler.Shared.Throttle("AutoEliminateFishAwareness-EnterFishing")) return false;
+        if (DService.Instance().ObjectTable.LocalPlayer == null || DService.Instance().Condition.IsBetweenAreas || !UIModule.IsScreenReady()) return false;
+
+        ExecuteCommandManager.Instance().ExecuteCommand(ExecuteCommandFlag.Fishing);
+        return DService.Instance().Condition[ConditionFlag.Fishing];
+    }
+
     private class Config : ModuleConfig
     {
+        public bool          AutoCast       = true;
         public HashSet<uint> BlacklistZones = [];
         public string        ExtraCommands  = string.Empty;
 
@@ -172,6 +191,13 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
     #region 常量
 
     private const uint TARGET_CONTENT = 195;
+
+    private static readonly FrozenSet<string> ValidChatMessages = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        LuminaWrapper.GetLogMessageText(3516),
+        LuminaWrapper.GetLogMessageText(5517),
+        LuminaWrapper.GetLogMessageText(5518)
+    }.ToFrozenSet();
 
     #endregion
 }

--- a/General/AutoEliminateFishAwareness.cs
+++ b/General/AutoEliminateFishAwareness.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
@@ -11,7 +10,6 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using OmenTools.ImGuiOm.Widgets.Combos;
 using OmenTools.Info.Game.Enums;
 using OmenTools.Interop.Game.Helpers;
-using OmenTools.Interop.Game.Lumina;
 using OmenTools.OmenService;
 using OmenTools.Threading;
 
@@ -75,10 +73,6 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
 
         ImGui.NewLine();
 
-        if (ImGui.Checkbox(Lang.Get("AutoEliminateFishAwareness-AutoCast"), ref config.AutoCast))
-            config.Save(this);
-        ImGuiOm.HelpMarker(Lang.Get("AutoEliminateFishAwareness-AutoCastHelp"));
-        
         if (ImGui.Checkbox(Lang.Get("AutoEliminateFishAwareness-LogoutWhenGlobalWarning"), ref config.LogoutWhenGlobalWarning))
             config.Save(this);
     }
@@ -132,11 +126,8 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
                 else
                     return;
 
-                if (config.AutoCast)
-                    TaskHelper.Enqueue(EnterFishing, "进入钓鱼状态");
-                else
-                    TaskHelper.Enqueue(() => ActionManager.Instance()->GetActionStatus(ActionType.Action, 289) == 0, "等待技能抛竿可用");
-
+                TaskHelper.Enqueue(() => ActionManager.Instance()->GetActionStatus(ActionType.Action, 289) == 0, "等待技能抛竿可用");
+                
                 TaskHelper.Enqueue
                 (
                     () =>
@@ -170,18 +161,8 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
         return true;
     }
 
-    private static bool EnterFishing()
-    {
-        if (!Throttler.Shared.Throttle("AutoEliminateFishAwareness-EnterFishing")) return false;
-        if (DService.Instance().ObjectTable.LocalPlayer == null || DService.Instance().Condition.IsBetweenAreas || !UIModule.IsScreenReady()) return false;
-
-        ExecuteCommandManager.Instance().ExecuteCommand(ExecuteCommandFlag.Fishing);
-        return DService.Instance().Condition[ConditionFlag.Fishing];
-    }
-
     private class Config : ModuleConfig
     {
-        public bool          AutoCast       = true;
         public HashSet<uint> BlacklistZones = [];
         public string        ExtraCommands  = string.Empty;
 
@@ -191,13 +172,6 @@ public unsafe class AutoEliminateFishAwareness : ModuleBase
     #region 常量
 
     private const uint TARGET_CONTENT = 195;
-
-    private static readonly FrozenSet<string> ValidChatMessages = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-    {
-        LuminaWrapper.GetLogMessageText(3516),
-        LuminaWrapper.GetLogMessageText(5517),
-        LuminaWrapper.GetLogMessageText(5518)
-    }.ToFrozenSet();
 
     #endregion
 }


### PR DESCRIPTION
移除了 AutoEliminateFishAwareness 的 AutoCast 配置项和对应 UI。

清除钓场警惕后的自动抛竿对钓鱼流程没有帮助，因为钓鱼一般要在抛竿前使用额外技能。
如果是为了在发送文本指令前确认当前能否钓鱼，当前已有的「等待抛竿可用」检查已经足够了。
