### PR TITLE
新增幻化模板管理模块

### DIFF
--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Apply.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Apply.cs
@@ -2,11 +2,21 @@ using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using OmenTools.Dalamud;
 using static FFXIVClientStructs.FFXIV.Client.UI.Agent.AgentMiragePrismMiragePlateData;
+using DailyRoutines.Extensions;
+using Lumina.Excel.Sheets;
+using OmenTools.Info.Game.Data;
+using OmenTools.Interop.Game.Lumina;
+using OmenTools.OmenService;
+using Control = FFXIVClientStructs.FFXIV.Client.Game.Control.Control;
 
 namespace DailyRoutines.ModulesPublic.Interface.UnifiedGlamourManager;
 
 public unsafe partial class UnifiedGlamourManager
 {
+    // 用于记录用户当前没有的幻化
+    private readonly List<PlateItemInfo> missingApplyItems = [];
+    private bool openMissingApplyItemsPopup;
+
     private void ApplySelectedItemToCurrentPlateSlot(UnifiedItem item)
     {
         if (!item.CanUseInPlate || !TryGetReadyPlateEditor(out var agent)) return;
@@ -109,5 +119,204 @@ public unsafe partial class UnifiedGlamourManager
 
         agent->Data->HasChanges          = true;
         agent->CharaView.IsUpdatePending = true;
+    }
+
+    private void SaveCurrentPlateAsPreset(string title, string note, PresetSource source)
+    {
+        var isInspect = source == PresetSource.OtherPlayer;
+        var items = isInspect ? GetInspectPlateItems() : GetCurrentPlateItems();
+        if (items.Count == 0) return;
+
+        // get目标对象的种族/性别
+        if (isInspect)
+        {
+            sourceRace = (byte)AgentInspect.Instance()->CharaView.Race;
+            sourceSex  = (byte)AgentInspect.Instance()->CharaView.Sex;
+        }
+        else
+        {
+            sourceRace = Control.GetLocalPlayer()->DrawData.CustomizeData.Race;
+            sourceSex  = Control.GetLocalPlayer()->DrawData.CustomizeData.Sex;
+        }
+
+        // 根据玩家设置的内容/时间生成一个新的预设
+        PlatePreset preset = new()
+        {
+            Title     = string.IsNullOrWhiteSpace(title) ? GetDefaultPresetTitle(source) : title.Trim(),
+            Note      = note.Trim(),
+            Race      = GetRaceName(sourceRace, sourceSex),
+            Sex       = GetSexName(sourceSex),
+            CreatedAt = DateTime.Now
+        };
+
+        preset.Items.AddRange(items);
+
+        // 保存预设，清空输入框
+        config.Presets.Add(preset);
+        selectedPreset = preset;
+        newPresetTitle = string.Empty;
+        newPresetNote  = string.Empty;
+
+        config.Save(this);
+        NotifyHelper.Instance().NotificationSuccess(Lang.Get("SavedSuccessfully"));
+    }
+
+    private bool StartApplyPreset()
+    {
+        if (!TryGetReadyPlateEditor(out var applyAgent) ||
+            !TryGetLoadedMirageManager(out _) ||
+            selectedPreset == null)
+            return false;
+
+        var entries = selectedPreset.Items
+                                    .Where(x => x.SlotIndex < PLATE_SLOT_ADDON_TEXT_IDS.Length)
+                                    .OrderBy(x => x.SlotIndex)
+                                    .ToList();
+
+        missingApplyItems.Clear();
+
+        foreach (var entry in entries)
+        {
+            var itemID = ItemUtil.GetBaseId(entry.ItemID).ItemId;
+
+            var target = items
+                         .Where(x =>
+                             x.ItemID == itemID &&
+                             x.CanUseInPlate &&
+                             x.IsCompatibleWithSlot(entry.SlotIndex))
+                         .OrderBy(x => x.IsSetPart)
+                         .ThenByDescending(x => x.InPrismBox)
+                         .FirstOrDefault();
+
+            if (target == null)
+            {
+                missingApplyItems.Add(entry);
+                continue;
+            }
+
+            var sentApply      = false;
+            var originStain0ID = 0U;
+            var originStain1ID = 0U;
+
+            TaskHelper.Enqueue
+            (() =>
+                {
+                    if (!TryGetReadyPlateEditor(out var applyAgent))
+                        return false;
+
+                    var slot = (int)entry.SlotIndex;
+
+                    if (!sentApply)
+                    {
+                        applyAgent->Data->SelectedItemIndex = entry.SlotIndex;
+
+                        if (target.InPrismBox && TryApplyPrismBoxItem(applyAgent, target))
+                        {
+                            if (!target.IsSetPart)
+                            {
+                                originStain0ID = target.Stain0ID;
+                                originStain1ID = target.Stain1ID;
+                            }
+
+                            sentApply = true;
+                            return false;
+                        }
+
+                        if (target.InCabinet && TryApplyCabinetItem(applyAgent, target))
+                        {
+                            sentApply = true;
+                            return false;
+                        }
+
+                        missingApplyItems.Add(entry);
+                        return true;
+                    }
+
+                    ref var currentItem = ref applyAgent->Data->CurrentItems[slot];
+
+                    if (currentItem.ItemId == 0 || ItemUtil.GetBaseId(currentItem.ItemId).ItemId != itemID)
+                    {
+                        sentApply = false;
+                        return false;
+                    }
+
+                    if (entry.Stain0ID != (byte)originStain0ID)
+                    {
+                        currentItem.Flags |= ItemFlag.HasStain0;
+
+                        var dye0ID = LuminaGetter.TryGetRow<Stain>(entry.Stain0ID, out var dye0Row)
+                            ? dye0Row.Item[0].RowId
+                            : 0;
+
+                        Inventories.Player.TryGetFirstItem(x => x.ItemId == dye0ID, out var dye0);
+                        applyAgent->SetItemStain(entry.SlotIndex, entry.Stain0ID, dye0, dye0ID, 0);
+                    }
+
+                    if (entry.Stain1ID != (byte)originStain1ID)
+                    {
+                        currentItem.Flags |= ItemFlag.HasStain1;
+
+                        var dye1ID = LuminaGetter.TryGetRow<Stain>(entry.Stain1ID, out var dye1Row)
+                            ? dye1Row.Item[0].RowId
+                            : 0;
+
+                        Inventories.Player.TryGetFirstItem(x => x.ItemId == dye1ID, out var dye1);
+                        applyAgent->SetItemStain(entry.SlotIndex, entry.Stain1ID, dye1, dye1ID, 1);
+                    }
+
+                    MarkPlateSelectionDirty(applyAgent);
+                    return true;
+                }
+            );
+
+            TaskHelper.DelayNext(150);
+        }
+
+        TaskHelper.Enqueue
+        (() =>
+            {
+                openMissingApplyItemsPopup = missingApplyItems.Count > 0;
+                return true;
+            }
+        );
+
+        return true;
+    }
+
+    private bool StartTryOnPreset(PlatePreset preset)
+    {
+        if (DService.Instance().Condition.IsOccupiedInEvent ||
+            AgentTryon.Instance() == null)
+            return false;
+
+        var entries = preset.Items
+                            .Where(x =>
+                                x.ItemID > 0 &&
+                                x.SlotIndex < PLATE_SLOT_ADDON_TEXT_IDS.Length &&
+                                LuminaGetter.TryGetRow<Item>(ItemUtil.GetBaseId(x.ItemID).ItemId, out _))
+                            .OrderBy(x => x.SlotIndex)
+                            .ToList();
+
+        if (entries is not { Count: > 0 })
+        {
+            TaskHelper.Abort();
+            return true;
+        }
+
+        AgentTryon.Instance()->SaveDeleteOutfit = true;
+
+        foreach (var entry in entries)
+        {
+            TaskHelper.Enqueue
+            (() =>
+                {
+                    AgentTryon.TryOn(0, entry.ItemID, entry.Stain0ID, entry.Stain1ID);
+                    return true;
+                }
+            );
+            TaskHelper.DelayNext(50);
+        }
+
+        return true;
     }
 }

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Config.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Config.cs
@@ -13,6 +13,11 @@ public partial class UnifiedGlamourManager
     {
         public bool            UseGridView = true;
         public List<SavedItem> Favorites   = [];
+        
+        public List<PlatePreset> Presets = [];
+        public bool OnlyCurrentRace;
+        public bool OnlyCurrentSex;
+
     }
 
     private void NormalizeConfig()

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Constants.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Constants.cs
@@ -5,22 +5,28 @@ namespace DailyRoutines.ModulesPublic.Interface.UnifiedGlamourManager;
 
 public partial class UnifiedGlamourManager
 {
-    private const string PLATE_EDITOR_ADDON_NAME           = nameof(MiragePrismMiragePlate);
-    private const uint   MIRAGE_PLATE_OPEN_MODE_AGENT_SHOW = 0;
-    private const string FAVORITE_ICON_ON                  = "★";
-    private const string FAVORITE_ICON_OFF                 = "☆";
+    private const string PLATE_EDITOR_ADDON_NAME = nameof(MiragePrismMiragePlate);
+    private const byte FEMALE_SEX                = 1;
+    private const string COMMAND                 = "ugm";
+    private const string STONE_SCRIPT_URL        = "https://greasyfork.org/en/scripts/580109-%E7%9F%B3%E4%B9%8B%E5%AE%B6%E5%B9%BB%E5%8C%96%E6%A8%A1%E6%9D%BF%E5%AF%BC%E5%85%A5dr";
+    private const string STONE_URL               = "https://ff14risingstones.web.sdo.com/pc/index.html#/glamour";
+    private const string FAVORITE_ICON_ON        = "★";
+    private const string FAVORITE_ICON_OFF       = "☆";
+    private string newPresetTitle;
+    private string newPresetNote;
 
-    private const int TASK_TIMEOUT_MS         = 30_000;
-    private const int REFRESH_STEP_DELAY_MS   = 1;
-    private const int APPLY_RETRY_DELAY_MS    = 50;
-    private const int DEFAULT_MIN_EQUIP_LEVEL = 1;
-    private const int DEFAULT_MAX_EQUIP_LEVEL = 100;
-    private const int MAX_EQUIP_LEVEL_INPUT   = 999;
 
-    private const uint PRISM_BOX_CAPACITY = 800;
-
+    private const int TASK_TIMEOUT_MS              = 30_000;
+    private const int REFRESH_STEP_DELAY_MS        = 1;
+    private const int APPLY_RETRY_DELAY_MS         = 50;
+    private const int DEFAULT_MIN_EQUIP_LEVEL      = 1;
+    private const int DEFAULT_MAX_EQUIP_LEVEL      = 100;
+    private const int MAX_EQUIP_LEVEL_INPUT        = 999;
     private const int VIRTUALIZED_LIST_BUFFER_ROWS = 3;
     private const int VIRTUALIZED_GRID_BUFFER_ROWS = 2;
+
+    private const uint MIRAGE_PLATE_OPEN_MODE_AGENT_SHOW = 0;
+    private const uint PRISM_BOX_CAPACITY                = 800;
 
     private static readonly SourceFilter[] SourceFilters =
     [
@@ -58,6 +64,14 @@ public partial class UnifiedGlamourManager
         [8, 9, 10, 11, 12, 13, 14, 15],
         [16, 17, 18]
     ];
+
+    private static readonly uint[] PLATE_SLOT_ADDON_TEXT_IDS =
+    [
+        11960, 11961, 11962, 11963, 11964, 11965, 11966, 11968, 11967, 11969, 750, 749
+    ];
+    
+    // 5 是腰带，13 是职业水晶
+    private static readonly int[] PLATE_SLOTS = [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12];
 
     private static string[] JobFilterNames
     {

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Data.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Data.cs
@@ -9,6 +9,7 @@ using GameCabinet = FFXIVClientStructs.FFXIV.Client.Game.UI.Cabinet;
 using ItemSheet = Lumina.Excel.Sheets.Item;
 using static FFXIVClientStructs.FFXIV.Client.UI.Agent.AgentMiragePrismMiragePlateData;
 using Action = System.Action;
+using Lumina.Excel.Sheets;
 
 namespace DailyRoutines.ModulesPublic.Interface.UnifiedGlamourManager;
 
@@ -214,4 +215,72 @@ public unsafe partial class UnifiedGlamourManager
         name = item.Name.ExtractText();
         return !string.IsNullOrWhiteSpace(name);
     }
+
+    private static List<PlateItemInfo> GetCurrentPlateItems()
+    {
+        if (!TryGetReadyPlateEditor(out var agent)) return [];
+
+        List<PlateItemInfo> items = [];
+
+        var currentItems = agent->Data->CurrentItems;
+
+        for (var i = 0; i < currentItems.Length; i++)
+        {
+            var item = currentItems[i];
+            if (item.ItemId == 0) continue;
+
+            items.Add(new(
+                (uint)i,
+                item.ItemId,
+                item.StainIds[0],
+                item.StainIds[1]));
+        }
+
+        return items;
+    }
+
+    private static List<PlateItemInfo> GetInspectPlateItems()
+    {
+        if (!InventoryType.Examine.TryGetItems(
+                x => x.ItemId != 0 && PLATE_SLOTS.Contains(x.Slot),
+                out var inspectItems))
+            return [];
+
+        List<PlateItemInfo> items = [];
+
+        foreach (var item in inspectItems)
+        {
+            var itemID = item.GlamourId != 0 ? item.GlamourId : item.ItemId;
+            var plateSlot = (uint)Array.IndexOf(PLATE_SLOTS, item.Slot);
+            if (itemID == 0) continue;
+
+            items.Add(new(
+                plateSlot,
+                itemID,
+                item.Stains[0],
+                item.Stains[1]));
+        }
+
+        return items;
+    }
+
+    private static string GetRaceName(byte race, byte sex) =>
+        !LuminaGetter.TryGetRow(race, out Race raceRow)
+            ? Lang.Get("Unknown")
+            : sex == FEMALE_SEX
+                ? raceRow.Feminine.ToString() ?? Lang.Get("Unknown")
+                : raceRow.Masculine.ToString() ?? Lang.Get("Unknown");
+    private static string GetSexName(byte sex) =>
+        sex == FEMALE_SEX
+            ? LuminaWrapper.GetAddonText(15609)
+            : LuminaWrapper.GetAddonText(15608);
+    
+    private static string GetDefaultPresetTitle(PresetSource source) =>
+    source switch
+    {
+        PresetSource.Self => $"{Lang.Get("UnifiedGlamourManager-Preset-UntitledPreset")}-{LuminaWrapper.GetAddonText(3991)}",
+        PresetSource.OtherPlayer => $"{Lang.Get("UnifiedGlamourManager-Preset-UntitledPreset")}-{LuminaWrapper.GetAddonText(7979)}",
+        _ => Lang.Get("UnifiedGlamourManager-Preset-UntitledPreset")
+    };
+
 }

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Filter.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Filter.cs
@@ -7,7 +7,8 @@ public unsafe partial class UnifiedGlamourManager
     private readonly Dictionary<ulong, bool> jobFilterCache       = [];
     private readonly Dictionary<ulong, bool> plateSlotFilterCache = [];
 
-    private string            searchText               = string.Empty;
+    private string searchText   = string.Empty;
+    private string presetSearch = string.Empty;
     private SourceFilter      sourceFilter             = SourceFilter.All;
     private SortMode          sortMode                 = SortMode.FavoriteThenNameAsc;
     private SetRelationFilter setRelationFilter        = SetRelationFilter.All;
@@ -17,9 +18,16 @@ public unsafe partial class UnifiedGlamourManager
     private int               maxEquipLevel = DEFAULT_MAX_EQUIP_LEVEL;
     private int               selectedJobFilterIndex;
     private bool              requestClearFavoritesConfirm;
-    private bool              filteredItemsDirty  = true;
-    private uint              lastFilterPlateSlot = uint.MaxValue;
-    private UnifiedItem?      selectedItem;
+    private bool              filteredItemsDirty = true;
+
+    private uint lastFilterPlateSlot = uint.MaxValue;
+    
+    private byte sourceRace;
+    private byte sourceSex;
+
+    private UnifiedItem? selectedItem;
+    private PlatePreset? selectedPreset;
+
 
     private bool PassFilter(UnifiedItem item)
     {

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Models.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.Models.cs
@@ -31,6 +31,13 @@ public partial class UnifiedGlamourManager
         NonSetOnly
     }
 
+    // 模版来源
+    private enum PresetSource
+    {
+        Self,
+        OtherPlayer
+    }
+
     private sealed class UnifiedItem : IEquatable<UnifiedItem>
     {
         public uint   ItemID                 { get; set; }
@@ -195,6 +202,24 @@ public partial class UnifiedGlamourManager
         public long   AddedAt { get; set; }
     }
 
+    // 预设模版
+    private sealed class PlatePreset
+    {
+        // 玩家设置的标题/备注
+        public string Title = string.Empty;
+        public string Note = string.Empty;
+
+        // 当前保存的游戏角色的种族/性别
+        public string Race = string.Empty;
+        public string Sex = string.Empty;
+
+        // 保存的时间
+        public DateTime CreatedAt = DateTime.Now;
+
+        // 当前投影模板的所有内容
+        public List<PlateItemInfo> Items = [];
+    }
+
     private readonly record struct SetPartInfo
     (
         uint   ItemID,
@@ -207,4 +232,36 @@ public partial class UnifiedGlamourManager
         uint                          AddonTextID,
         Func<EquipSlotCategory, bool> CanUse
     );
+
+    // 投影模板
+    private readonly record struct PlateItemInfo
+    (
+        uint SlotIndex,
+        uint ItemID,
+        byte Stain0ID,
+        byte Stain1ID
+    );
+
+    // UIOperation/AutoGlamourDresser.cs
+    // 投影台
+    private readonly record struct PrismBoxItemInfo
+    (
+        uint  Index,
+        uint  RawItemID,
+        uint  ItemID,
+        uint  Stain0ID,
+        uint  Stain1ID,
+        bool  IsGlamorous,
+        ulong ModelMain,
+        uint  EquipSlotCategoryRowID
+    )
+    {
+        public bool IsGlamourModelValid =>
+            IsGlamorous &&
+            ModelMain              != 0 &&
+            EquipSlotCategoryRowID != 0;
+
+        public bool IsStained =>
+            Stain0ID != 0 || Stain1ID != 0;
+    }
 }

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.UI.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.UI.cs
@@ -3,21 +3,53 @@ using Dalamud.Interface.Utility;
 using Lumina.Excel.Sheets;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.OmenService;
+using DailyRoutines.Extensions;
+using Dalamud.Utility;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using Control = FFXIVClientStructs.FFXIV.Client.Game.Control.Control;
 
 namespace DailyRoutines.ModulesPublic.Interface.UnifiedGlamourManager;
 
 public unsafe partial class UnifiedGlamourManager
 {
+    private PlatePreset? editingPreset;
+    private string editPresetTitleInput = string.Empty;
+    private string editPresetNoteInput  = string.Empty;
+    
+    protected override void ConfigUI()
+    {
+        ImGui.TextColored(KnownColor.LightSkyBlue.ToVector4(), Lang.Get("Command"));
+
+        ImGui.TextUnformatted($"/pdr {COMMAND} → {Lang.Get("UnifiedGlamourManager-Preset-CommandHelp")}");
+
+        // 打开下载用于石之家导出的脚本页面(国服only)
+        if (GameState.IsCN)
+        {
+            ImGui.NewLine();
+
+            ImGui.TextColored(KnownColor.LightSkyBlue.ToVector4(), "石之家导入功能");
+
+            ImGui.TextWrapped
+            (
+                "如需使用石之家导入功能, 需要先安装浏览器脚本。\n" +
+                "安装脚本前, 请先为浏览器安装 Tampermonkey / Violentmonkey 等用户脚本管理器。\n" +
+                "安装完成后, 再打开脚本页面并点击 Install this script 安装导入脚本。\n" +
+                "安装导入脚本后, 打开石之家幻化详情页, 页面右下角会出现复制按钮。\n" +
+                "点击复制后, 回到本模块中使用导入功能。"
+            );
+
+            if (ImGui.Button("获取导入脚本"))
+                Util.OpenLink(STONE_SCRIPT_URL);
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("打开石之家"))
+                Util.OpenLink(STONE_URL);
+        }
+    }
+
     protected override void OverlayPreDraw()
     {
-        if (Overlay?.IsOpen == true &&
-            (!TryGetReadyPlateEditor(out var agent) ||
-             agent->Data->OpenMode != MIRAGE_PLATE_OPEN_MODE_AGENT_SHOW))
-        {
-            Overlay.IsOpen = false;
-            return;
-        }
-
         var minSize = new Vector2
         (
             ImGui.GetFrameHeight()               * 28f,
@@ -29,9 +61,49 @@ public unsafe partial class UnifiedGlamourManager
 
     protected override void OverlayUI()
     {
-        DrawTopBar();
-        DrawMainLayout();
-        DrawConfirmPopups();
+        if (DService.Instance().Condition.IsBetweenAreas) return;
+
+        var storage       = ImGui.GetStateStorage();
+        var selectedTabID = ImGui.GetID("##UnifiedGlamourManagerSelectedTab");
+        var selectedTab   = storage.GetInt(selectedTabID, 0);
+
+        var spacing = ImGui.GetStyle().ItemSpacing.X;
+        var tabSize = new Vector2
+        (
+            (ImGui.GetContentRegionAvail().X - spacing) * 0.5f,
+            ImGui.GetFrameHeight()
+        );
+
+        using (ImRaii.PushStyle(ImGuiStyleVar.SelectableTextAlign, new Vector2(0.5f, 0.5f)))
+        {
+            if (ImGui.Selectable(Lang.Get("UnifiedGlamourManagerTitle"), selectedTab == 0, ImGuiSelectableFlags.None, tabSize))
+                storage.SetInt(selectedTabID, 0);
+
+            ImGui.SameLine();
+
+            if (ImGui.Selectable(Lang.Get("UnifiedGlamourManager-GlamourPresetManagerTitle"), selectedTab == 1, ImGuiSelectableFlags.None, tabSize))
+                storage.SetInt(selectedTabID, 1);
+        }
+
+        ImGui.Separator();
+
+        selectedTab = storage.GetInt(selectedTabID, 0);
+
+        if (selectedTab == 0)
+        {
+            DrawTopBar();
+            DrawMainLayout();
+            DrawConfirmPopups();
+        }
+        else
+        {
+            DrawStatusBar();
+            DrawPresetSearchAndFilterBar();
+            ImGui.Separator();
+
+            DrawPresetMainLayout();
+            DrawMissingApplyItemsPopup();
+        }
     }
 
     private static void DrawSectionTitle(string text)
@@ -91,10 +163,7 @@ public unsafe partial class UnifiedGlamourManager
         if (!child) return;
 
         ImGui.AlignTextToFramePadding();
-        ImGui.TextDisabled
-        (
-            $"{LuminaWrapper.GetAddonText(11910)}: {prismBoxItemCount} / {LuminaWrapper.GetAddonText(12216)}: {cabinetItemCount} / {LuminaWrapper.GetAddonText(929)}: {StoredItemCount}"
-        );
+        DrawStatusBar();
 
         if (ImGui.Button(Lang.Get("Refresh")))
             StartRefreshAll();
@@ -107,7 +176,7 @@ public unsafe partial class UnifiedGlamourManager
             ImGui.GetContentRegionAvail().X
         );
         ImGui.SetNextItemWidth(searchWidth);
-        if (ImGui.InputTextWithHint("##Search", Lang.Get("Search"), ref searchText))
+        if (ImGui.InputTextWithHint("##UnifiedItemSearch", Lang.Get("Search"), ref searchText, 128))
             MarkFilteredItemsDirty();
 
         ImGui.SameLine();
@@ -458,7 +527,7 @@ public unsafe partial class UnifiedGlamourManager
         var cellSize       = MathF.Floor((availableWidth - (spacing                  * (columns     - 1))) / columns);
         cellSize = Math.Clamp(cellSize, minCellSize, maxCellSize);
 
-        var iconSize        = MathF.Max(ImGui.GetFrameHeight() * 1.3f, cellSize - (ImGui.GetStyle().FramePadding.X * 2f));
+        var iconSize        = MathF.Max(ImGui.GetFrameHeight() * 1.3f, cellSize - ImGui.GetStyle().FramePadding.X);
         var start           = ImGui.GetCursorScreenPos();
         var drawList        = ImGui.GetWindowDrawList();
         var rows            = (filtered.Count + columns - 1) / columns;
@@ -631,6 +700,435 @@ public unsafe partial class UnifiedGlamourManager
         ImGui.TextDisabled(Lang.Get("UnifiedGlamourManager-RightClickFavoriteHint"));
     }
 
+    // UI - Preset
+    private void DrawStatusBar()
+    {
+        var mirageLoaded = TryGetLoadedMirageManager(out _);
+        var cabinetLoaded = GetLoadedCabinet() is not null;
+
+        // 投影台状态
+        ImGui.AlignTextToFramePadding();
+        ImGui.TextDisabled($"{LuminaWrapper.GetAddonText(11910)}:");
+        ImGui.SameLine();
+        ImGui.TextColored(
+            (mirageLoaded ? KnownColor.LimeGreen : KnownColor.Red).ToVector4(),
+            mirageLoaded ? Lang.Get("Connected") : Lang.Get("Disconnected"));
+
+        ImGui.SameLine();
+        // 收藏柜状态
+        ImGui.TextDisabled($"{LuminaWrapper.GetAddonText(12216)}:");
+        ImGui.SameLine();
+        ImGui.TextColored(
+            (cabinetLoaded ? KnownColor.LimeGreen : KnownColor.Red).ToVector4(),
+            cabinetLoaded ? Lang.Get("Connected") : Lang.Get("Disconnected"));
+    }
+    
+    private void DrawPresetSearchAndFilterBar()
+    {
+        using var table = ImRaii.Table("##PresetSearchAndFilterBar", 2, ImGuiTableFlags.SizingStretchProp);
+        if (!table) return;
+
+        ImGui.TableSetupColumn("##Search", ImGuiTableColumnFlags.WidthStretch);
+        ImGui.TableSetupColumn("##Filters", ImGuiTableColumnFlags.WidthFixed);
+        // 搜索框
+        ImGui.TableNextColumn();
+        ImGui.SetNextItemWidth(-1f);
+        ImGui.InputTextWithHint("##PresetSearch", Lang.Get("Search"), ref presetSearch, 128);
+        // 筛选条件
+        ImGui.TableNextColumn();
+        if (ImGui.Checkbox(Lang.Get("UnifiedGlamourManager-Preset-OnlyCurrentRace"), ref config.OnlyCurrentRace))
+            config.Save(this);
+        ImGui.SameLine();
+        if (ImGui.Checkbox(Lang.Get("UnifiedGlamourManager-Preset-OnlyCurrentSex"), ref config.OnlyCurrentSex))
+            config.Save(this);
+    }
+
+    private void DrawPresetMainLayout()
+    {
+        var size = ImGui.GetContentRegionAvail();
+        if (size.X <= 0f || size.Y <= 0f) return;
+
+        using var table = ImRaii.Table("##GlamourPresetMainLayout", 2, ImGuiTableFlags.Resizable, size);
+        if (!table) return;
+
+        ImGui.TableSetupColumn("##PresetList", ImGuiTableColumnFlags.WidthStretch, 0.35f);
+        ImGui.TableSetupColumn("##PresetDetail", ImGuiTableColumnFlags.WidthStretch, 0.65f);
+
+        // 预设列表
+        ImGui.TableNextColumn();
+        DrawPresetList();
+
+        // 预设详情
+        ImGui.TableNextColumn();
+        DrawPresetDetail();
+    }
+
+    private void DrawPresetList()
+    {
+        // 获取玩家的种族/性别
+        var player = Control.GetLocalPlayer();
+        var race   = GetRaceName(player->DrawData.CustomizeData.Race, player->DrawData.CustomizeData.Sex);
+        var sex    = GetSexName(player->DrawData.CustomizeData.Sex);
+
+        var keyword = presetSearch.Trim();
+
+        var visiblePresets = config.Presets
+                                .Where(x =>
+                                    (!config.OnlyCurrentRace || x.Race == race) &&
+                                    (!config.OnlyCurrentSex || x.Sex == sex) &&
+                                    (keyword.Length == 0 ||
+                                        x.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase) ||
+                                        x.Note.Contains(keyword, StringComparison.OrdinalIgnoreCase) ||
+                                        x.Items.Any(item =>
+                                            LuminaGetter.GetRow<Item>(ItemUtil.GetBaseId(item.ItemID).ItemId) is { } itemRow &&
+                                            itemRow.Name.ToString().Contains(keyword, StringComparison.OrdinalIgnoreCase))))
+                                .OrderByDescending(x => x.CreatedAt)
+                                .ToList();
+
+        // 当前筛选数/总数
+        ImGui.AlignTextToFramePadding();
+        ImGui.TextColored(TitleColor, $"{Lang.Get("List")} {visiblePresets.Count} / {config.Presets.Count}");
+        ImGui.Separator();
+
+        // 导入/导入试穿
+        using (var buttonTable = ImRaii.Table("##PresetImportButtons", 2, ImGuiTableFlags.SizingStretchProp))
+        {
+            if (buttonTable)
+            {
+                ImGui.TableSetupColumn("##Import", ImGuiTableColumnFlags.WidthStretch, 1f);
+                ImGui.TableSetupColumn("##TryOnImport", ImGuiTableColumnFlags.WidthStretch, 1f);
+
+                ImGui.TableNextRow();
+
+                ImGui.TableNextColumn();
+                if (ImGuiOm.ButtonIconWithText(FontAwesomeIcon.FileImport, Lang.Get("Import"), new Vector2(-1f, 0f)))
+                {
+                    var preset = ImportFromClipboard<PlatePreset>();
+                    if (preset != null)
+                    {
+                        preset.Title = preset.Title.Trim();
+
+                        preset.CreatedAt = DateTime.Now;
+                        config.Presets.Add(preset);
+                        selectedPreset = preset;
+                        config.Save(this);
+                    }
+                }
+
+                ImGui.TableNextColumn();
+                using (ImRaii.Disabled(TaskHelper.IsBusy || AgentTryon.Instance() == null || DService.Instance().Condition.IsOccupiedInEvent))
+                {
+                    if (ImGui.Button(Lang.Get("UnifiedGlamourManager-Preset-TryOnImportedContent"), new Vector2(-1f, 0f)))
+                        TaskHelper.Enqueue(() => StartTryOnPreset(ImportFromClipboard<PlatePreset>()));
+                }
+            }
+        }
+
+            ImGui.Separator();
+
+            using var child = ImRaii.Child("##PresetListChild", Vector2.Zero, true);
+            if (!child) return;
+
+            if (visiblePresets.Count == 0)
+            {
+                ImGui.TextDisabled(Lang.Get("UnifiedGlamourManager-NoSearchResult"));
+            }
+            else
+            {
+                foreach (var preset in visiblePresets)
+                {
+                    using var id = ImRaii.PushId($"{preset.Title}-{preset.CreatedAt.Ticks}");
+
+                    var pos = ImGui.GetCursorScreenPos();
+                    var size = new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetTextLineHeightWithSpacing() * 3.5f);
+                    var selected = selectedPreset == preset;
+
+                    if (ImGui.InvisibleButton("##PresetItem", size))
+                        selectedPreset = preset;
+
+                    // 双击修改
+                    var hovered = ImGui.IsItemHovered();
+                    ImGuiOm.TooltipHover(Lang.Get("UnifiedGlamourManager-Preset-DoubleClickEditHint"));
+                    
+                    if (hovered && ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+                    {
+                        selectedPreset = preset;
+                        editingPreset = preset;
+                        editPresetTitleInput = preset.Title;
+                        editPresetNoteInput = preset.Note;
+                        ImGui.OpenPopup("EditPresetPopup");
+                    }
+
+                    var drawList = ImGui.GetWindowDrawList();
+                    var color = selected
+                                       ? ImGui.GetColorU32(ImGuiCol.HeaderActive)
+                                       : hovered
+                                           ? ImGui.GetColorU32(ImGuiCol.HeaderHovered)
+                                           : ImGui.GetColorU32(ImGuiCol.FrameBg);
+
+                    drawList.AddRectFilled(pos, pos + size, color, ImGui.GetStyle().FrameRounding);
+                    drawList.AddRect(pos, pos + size, ImGui.GetColorU32(ImGuiCol.Border), ImGui.GetStyle().FrameRounding);
+
+                    var textPos = pos + ImGui.GetStyle().FramePadding;
+
+                    // 模板标题
+                    drawList.AddText
+                    (
+                        textPos,
+                        ImGui.GetColorU32(ImGuiCol.Text),
+                        string.IsNullOrWhiteSpace(preset.Title) ? Lang.Get("UnifiedGlamourManager-Preset-UntitledPreset") : preset.Title
+                    );
+
+                    // 种族/性别/保存时间
+                    drawList.AddText
+                    (
+                        textPos + new Vector2(0f, ImGui.GetTextLineHeightWithSpacing()),
+                        ImGui.GetColorU32(ImGuiCol.TextDisabled),
+                        $"{preset.Race} / {preset.Sex} / {preset.CreatedAt:yyyy-MM-dd HH:mm}"
+                    );
+
+                    // 备注
+                    drawList.AddText
+                    (
+                        textPos + new Vector2(0f, ImGui.GetTextLineHeightWithSpacing() * 2f),
+                        ImGui.GetColorU32(ImGuiCol.TextDisabled),
+                        $"{Lang.Get("Note")}: {(string.IsNullOrWhiteSpace(preset.Note) ? Lang.Get("None") : preset.Note)}"
+                    );
+
+                    ImGui.SetCursorScreenPos(pos + new Vector2(0f, size.Y + ImGui.GetStyle().ItemSpacing.Y));
+
+                    DrawEditPresetPopup();
+                }
+            }
+        }
+
+    private void DrawEditPresetPopup()
+    {
+        using (var popup = ImRaii.Popup("EditPresetPopup", ImGuiWindowFlags.AlwaysAutoResize))
+        {
+            if (popup)
+            {
+                if (editingPreset == selectedPreset)
+                {
+                    using (var table = ImRaii.Table("##EditPresetTable", 2))
+                    {
+                        if (table)
+                        {
+                            ImGui.TableSetupColumn("##Label", ImGuiTableColumnFlags.WidthFixed);
+                            ImGui.TableSetupColumn("##Input", ImGuiTableColumnFlags.WidthFixed, 120f * GlobalUIScale);
+
+                            ImGui.TableNextRow();
+                            ImGui.TableNextColumn();
+                            ImGui.AlignTextToFramePadding();
+                            ImGui.TextUnformatted($"{LuminaWrapper.GetAddonText(4534)}:");
+
+                            ImGui.TableNextColumn();
+                            ImGui.SetNextItemWidth(120f * GlobalUIScale);
+                            ImGui.InputTextWithHint("##EditPresetTitle", LuminaWrapper.GetAddonText(4534), ref editPresetTitleInput, 40);
+
+                            ImGui.TableNextRow();
+                            ImGui.TableNextColumn();
+                            ImGui.AlignTextToFramePadding();
+                            ImGui.TextUnformatted($"{Lang.Get("Note")}:");
+
+                            ImGui.TableNextColumn();
+                            ImGui.SetNextItemWidth(120f * GlobalUIScale);
+                            ImGui.InputTextMultiline
+                            (
+                                "##EditPresetNote",
+                                ref editPresetNoteInput,
+                                120,
+                                new(120f * GlobalUIScale, ImGui.GetTextLineHeightWithSpacing() * 3f)
+                            );
+                        }
+                    }
+
+                    if (ImGui.Button(Lang.Get("Confirm")))
+                    {
+                        if (!string.IsNullOrWhiteSpace(editPresetTitleInput))
+                            editingPreset.Title = editPresetTitleInput.Trim();
+
+                        editingPreset.Note = editPresetNoteInput.Trim();
+
+                        selectedPreset = editingPreset;
+                        config.Save(this);
+                        ImGui.CloseCurrentPopup();
+                    }
+
+                    ImGui.SameLine();
+
+                    if (ImGui.Button(Lang.Get("Cancel")))
+                        ImGui.CloseCurrentPopup();
+                }
+            }
+        }
+    }
+
+    private void DrawPresetDetail()
+    {
+        ImGui.AlignTextToFramePadding();
+        ImGui.TextColored(TitleColor, Lang.Get("UnifiedGlamourManager-Preset-PresetDetail"));
+        ImGui.Separator();
+
+        // 未选择
+        if (selectedPreset == null)
+        {
+            var text = LuminaWrapper.GetAddonText(1440);
+            var size = ImGui.GetContentRegionAvail();
+            var textSize = ImGui.CalcTextSize(text);
+
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() + MathF.Max(0f, (size.Y - textSize.Y) * 0.5f));
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + MathF.Max(0f, (size.X - textSize.X) * 0.5f));
+            ImGui.TextDisabled(text);
+            return;
+        }
+
+        // 模版内容
+        DrawSavedContent();
+        ImGui.Separator();
+
+        // 按钮
+        using var table = ImRaii.Table("##PresetActionButtons", 2, ImGuiTableFlags.SizingStretchProp);
+        if (!table) return;
+
+        ImGui.TableSetupColumn("##Left", ImGuiTableColumnFlags.WidthStretch, 1f);
+        ImGui.TableSetupColumn("##Right", ImGuiTableColumnFlags.WidthStretch, 1f);
+
+        ImGui.TableNextRow();
+
+        // 应用按钮
+        ImGui.TableNextColumn();
+        using (ImRaii.Disabled(TaskHelper.IsBusy || !TryGetReadyPlateEditor(out var agent) || agent->Data->OpenMode != 0))
+        {
+            if (ImGui.Button(Lang.Get("Apply"), new Vector2(-1f, 0f)))
+                TaskHelper.Enqueue(StartApplyPreset);
+        }
+
+        // 试穿按钮
+        ImGui.TableNextColumn();
+        using (ImRaii.Disabled(TaskHelper.IsBusy || AgentTryon.Instance() == null || DService.Instance().Condition.IsOccupiedInEvent))
+        {
+            if (ImGui.Button(LuminaWrapper.GetAddonText(2426), new Vector2(-1f, 0f)))
+                TaskHelper.Enqueue(() => StartTryOnPreset(selectedPreset));
+        }
+            
+        ImGui.TableNextRow();
+
+        // 导出按钮
+        ImGui.TableNextColumn();
+        if (ImGuiOm.ButtonIconWithText(FontAwesomeIcon.FileExport, Lang.Get("Export"), new Vector2(-1f, 0f)))
+            ExportToClipboard(selectedPreset);
+
+        // 删除按钮
+        ImGui.TableNextColumn();
+        if (ImGuiOm.ButtonIconWithText(FontAwesomeIcon.TrashAlt, Lang.Get("HoldCtrlToDelete"), new Vector2(-1f, 0f)))
+        {
+            if (ImGui.IsKeyDown(ImGuiKey.LeftCtrl))
+            {
+                config.Presets.Remove(selectedPreset);
+                selectedPreset = null;
+                config.Save(this);
+            }
+        }
+    }
+
+    private void DrawSavedContent()
+    {
+        if (selectedPreset == null) return;
+
+        using var child = ImRaii.Child
+        (
+            "##SavedContentChild",
+            new Vector2(0f, -(ImGui.GetFrameHeightWithSpacing() * 2.5f)),
+            true
+        );
+        if (!child) return;
+
+        using var table = ImRaii.Table
+        (
+            "##SavedContentTable",
+            3,
+            ImGuiTableFlags.RowBg         |
+            ImGuiTableFlags.BordersInnerH |
+            ImGuiTableFlags.ScrollY       |
+            ImGuiTableFlags.SizingStretchProp
+        );
+
+        if (!table) return;
+
+        ImGui.TableSetupColumn
+        (
+            Lang.Get("UnifiedGlamourManager-GlamourTargetSlot"),
+            ImGuiTableColumnFlags.WidthFixed,
+            ImGui.GetFrameHeight() * 3f
+        );
+        ImGui.TableSetupColumn(LuminaWrapper.GetAddonText(6942));
+        ImGui.TableSetupColumn(Lang.Get("Dye"), ImGuiTableColumnFlags.WidthStretch, 0.9f);
+        ImGui.TableHeadersRow();
+
+        foreach (var item in selectedPreset.Items
+                                           .Where(x => x.SlotIndex < PLATE_SLOT_ADDON_TEXT_IDS.Length)
+                                           .OrderBy(x => x.SlotIndex))
+        {
+            var itemRow = LuminaGetter.GetRow<Item>(ItemUtil.GetBaseId(item.ItemID).ItemId).GetValueOrDefault();
+            var size    = new Vector2(ImGui.GetFrameHeight());
+
+            ImGui.TableNextRow();
+
+            // 槽位
+            ImGui.TableNextColumn();
+            ImGui.AlignTextToFramePadding();
+            ImGui.TextUnformatted(LuminaWrapper.GetAddonText(PLATE_SLOT_ADDON_TEXT_IDS[item.SlotIndex]));
+
+            // 装备图标/名称
+            ImGui.TableNextColumn();
+            if (ImageHelper.GetGameIcon(itemRow.Icon) is { } itemIcon)
+                ImGui.Image(itemIcon.Handle, size);
+            ImGui.SameLine();
+            ImGui.TextUnformatted(itemRow.Name.ToString());
+
+            // 染色
+            ImGui.TableNextColumn();
+
+            var stain0 = LuminaGetter.GetRow<Stain>(item.Stain0ID).GetValueOrDefault();
+            var stain1 = LuminaGetter.GetRow<Stain>(item.Stain1ID).GetValueOrDefault();
+
+            DrawStainLabel(15970, stain0);
+
+            ImGui.SameLine();
+            ImGui.TextDisabled(" / ");
+            ImGui.SameLine();
+
+            DrawStainLabel(15971, stain1);
+        }
+    }
+
+    private void DrawMissingApplyItemsPopup()
+    {
+        if (openMissingApplyItemsPopup)
+        {
+            ImGui.OpenPopup("##MissingApplyItemsPopup");
+            openMissingApplyItemsPopup = false;
+        }
+
+        using var popup = ImRaii.PopupModal("##MissingApplyItemsPopup", ImGuiWindowFlags.AlwaysAutoResize);
+        if (!popup) return;
+
+        ImGui.TextDisabled(Lang.Get("UnifiedGlamourManager-Preset-MissingItemsText"));
+        ImGui.Separator();
+
+        foreach (var item in missingApplyItems)
+            ImGui.BulletText
+            (
+                $"{LuminaWrapper.GetAddonText(PLATE_SLOT_ADDON_TEXT_IDS[item.SlotIndex])}: {LuminaWrapper.GetItemName(ItemUtil.GetBaseId(item.ItemID).ItemId)}"
+            );
+
+        ImGui.Separator();
+
+        if (ImGui.Button(LuminaWrapper.GetAddonText(1219), new Vector2(-1f, 0f)))
+            ImGui.CloseCurrentPopup();
+    }
+
     #region 工具
 
     private static Vector4 GetCardBackgroundColor(bool selected, bool favorite, bool hovered)
@@ -650,8 +1148,6 @@ public unsafe partial class UnifiedGlamourManager
             : favorite
                 ? GoldColor
                 : MutedBorderColor;
-
-
 
     private static string GetSourceFilterLabel(SourceFilter filter) =>
         filter switch

--- a/Interface/UnifiedGlamourManager/UnifiedGlamourManager.cs
+++ b/Interface/UnifiedGlamourManager/UnifiedGlamourManager.cs
@@ -5,6 +5,9 @@ using DailyRoutines.Extensions;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Lumina.Excel.Sheets;
+using KamiToolKit.Nodes;
+using OmenTools.Threading;
+using OmenTools.OmenService;
 
 namespace DailyRoutines.ModulesPublic.Interface.UnifiedGlamourManager;
 
@@ -18,12 +21,21 @@ public unsafe partial class UnifiedGlamourManager : ModuleBase
         Author      = ["ErxCharlotte"]
     };
 
+    // 保存模版的按钮（在调查其他玩家的页面、编辑/选择自己幻化模版的页面）
+    private TextButtonNode? inspectSaveButtonNode;
+    private TextButtonNode? plateSaveButtonNode;
+
     public override ModulePermission Permission { get; } = new() { AllDefaultEnabled = true };
 
     protected override void Init()
     {
         config = Config.Load(this) ?? new();
         NormalizeConfig();
+
+        selectedPreset = config.Presets
+                            .OrderByDescending(x => x.CreatedAt)
+                            .FirstOrDefault();
+                            
         TaskHelper ??= new() { TimeoutMS = TASK_TIMEOUT_MS };
 
         Overlay ??= new(this);
@@ -34,12 +46,31 @@ public unsafe partial class UnifiedGlamourManager : ModuleBase
         Overlay.WindowName =  $"{Info.Title}###UnifiedGlamourManagerOverlay";
 
         var addonLifecycle = DService.Instance().AddonLifecycle;
-        addonLifecycle.RegisterListener(AddonEvent.PostSetup,   PLATE_EDITOR_ADDON_NAME, OnPlateEditorAddon);
+        addonLifecycle.RegisterListener(AddonEvent.PostSetup, PLATE_EDITOR_ADDON_NAME, OnPlateEditorAddon);
+        addonLifecycle.RegisterListener(AddonEvent.PostDraw, PLATE_EDITOR_ADDON_NAME, OnPlateEditorAddon);
         addonLifecycle.RegisterListener(AddonEvent.PreFinalize, PLATE_EDITOR_ADDON_NAME, OnPlateEditorAddon);
+        
+        addonLifecycle.RegisterListener(AddonEvent.PostDraw, "CharacterInspect", OnInspectAddon);
+        addonLifecycle.RegisterListener(AddonEvent.PreFinalize, "CharacterInspect", OnInspectAddon);
+
+        CommandManager.Instance().AddSubCommand(COMMAND, new(OnCommand) { HelpMessage = Lang.Get("UnifiedGlamourManager-CommandHelp") });
     }
 
-    protected override void Uninit() =>
+    protected override void Uninit()
+    {
+        CommandManager.Instance().RemoveSubCommand(COMMAND);
+
+        DService.Instance().AddonLifecycle.UnregisterListener(OnInspectAddon);
         DService.Instance().AddonLifecycle.UnregisterListener(OnPlateEditorAddon);
+
+        inspectSaveButtonNode?.Dispose();
+        inspectSaveButtonNode = null;
+
+        plateSaveButtonNode?.Dispose();
+        plateSaveButtonNode = null;
+    }
+    
+    private void OnCommand(string command, string arguments) => Overlay!.IsOpen = true;
 
     private void OnPlateEditorAddon(AddonEvent type, AddonArgs args)
     {
@@ -54,9 +85,69 @@ public unsafe partial class UnifiedGlamourManager : ModuleBase
                 }
 
                 break;
+            
+            case AddonEvent.PostDraw:
+                if (!MiragePrismMiragePlate->IsAddonAndNodesReady()) return;
+
+                if (plateSaveButtonNode == null)
+                {
+                    plateSaveButtonNode = new()
+                    {
+                        Size     = new(200, 28),
+                        Position = new(200, 10)
+                    };
+
+                    plateSaveButtonNode.AttachNode(MiragePrismMiragePlate->RootNode);
+                }
+
+                if (Throttler.Shared.Throttle("UnifiedGlamourManager-Preset-plateSaveButton"))
+                {
+                    plateSaveButtonNode.IsEnabled = GetCurrentPlateItems().Count > 0;
+                    plateSaveButtonNode.String    = Lang.Get("UnifiedGlamourManager-Preset-SaveGlamourPreset");
+                    plateSaveButtonNode.OnClick   = () => SaveCurrentPlateAsPreset(string.Empty, string.Empty, PresetSource.Self);
+                }
+                break;
 
             case AddonEvent.PreFinalize:
+                plateSaveButtonNode = null;
+                TaskHelper?.Abort();
                 Overlay.IsOpen = false;
+                break;
+        }
+    }
+
+    private void OnInspectAddon(AddonEvent type, AddonArgs? args)
+    {
+        switch (type)
+        {
+            case AddonEvent.PostDraw:
+                if (!CharacterInspect->IsAddonAndNodesReady()) return;
+
+                var designButtonNode = CharacterInspect->GetNodeById(6);
+                if (designButtonNode == null) return;
+
+                if (inspectSaveButtonNode == null)
+                {
+                    inspectSaveButtonNode = new()
+                    {
+                        Size     = new(designButtonNode->Width, designButtonNode->Height),
+                        Position = new(180, 10)
+                    };
+
+                    inspectSaveButtonNode.AttachNode(CharacterInspect->RootNode);
+                }
+
+                if (Throttler.Shared.Throttle("UnifiedGlamourManager-Preset-InspectButton"))
+                {
+                    inspectSaveButtonNode.IsEnabled = GetInspectPlateItems().Count > 0;
+                    inspectSaveButtonNode.String    = Lang.Get("UnifiedGlamourManager-Preset-SaveGlamourPreset");
+                    inspectSaveButtonNode.OnClick   = () => SaveCurrentPlateAsPreset(string.Empty, string.Empty, PresetSource.OtherPlayer);
+                }
+                break;
+
+            case AddonEvent.PreFinalize:
+                inspectSaveButtonNode = null;
+                TaskHelper?.Abort();
                 break;
         }
     }


### PR DESCRIPTION
## 概述

新增幻化模板管理模块，用于保存、管理、导入、导出和应用幻化模板。

模块支持从当前投影模板或调查其他玩家页面保存幻化数据，并可将已保存模板重新应用到投影模板中。

## 主要功能

- 新增 `/pdr gpm` 子命令，用于打开本模块的窗口
- 在模块配置页提供入口按钮，可打开模块主界面
- 在调查其他玩家页面新增保存按钮，可将目标玩家当前幻化保存为模板
- 在投影模板编辑页面新增保存按钮，可将自己的当前投影模板保存为模板
- 支持模板关键词（标题/备注/包含的装备）搜索
- 支持按当前角色种族 / 性别筛选模板
- 支持双击模板列表项编辑标题和备注
- 支持查看模板内保存的装备、槽位和双染色信息
- 支持导入 / 导出模板到剪贴板
- 支持试穿剪贴板中的模板内容
- 支持将已保存模板应用到当前投影模板
- 应用模板时会从投影台和收藏柜中查找可用装备
- 应用时如果存在玩家未拥有的装备，会弹窗列出缺失装备
- 配置页提供石之家导入脚本和石之家页面入口（不确定是否可以这么做， 还请老大指教一下。不行的话删除放在模块内的，把脚本放到DC上分享？）

## 测试

- `/pdr gpm` 可以正常打开模块窗口
- 配置页按钮可以正常打开模块窗口
- 打开调查其他玩家页面时，保存按钮显示正常
- 可以从调查其他玩家页面保存幻化模板
- 打开投影模板编辑页面时，保存按钮显示正常
- 可以从当前投影模板保存模板
- 模板搜索功能正常
- 种族 / 性别筛选正常
- 双击模板可以编辑标题和备注
- 模板导入 / 导出剪贴板正常
- 剪贴板模板试穿正常
- 应用模板到投影模板正常
- 主染色和副染色应用正常
- 缺失装备时会弹窗提示