### PR TITLE
优化 AutoIgnoreLoginLock 在登录排队时的处理

### DIFF
--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -148,7 +148,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     #region 常量
 
     private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE     = 31;
-    private const int  LOGIN_QUEUE_SOUND_FILTER_STICKY_MS = 1_000;
+    private const int  LOGIN_QUEUE_SOUND_FILTER_STICKY_MS = 1_500;
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -1,6 +1,7 @@
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
+using DailyRoutines.Extensions;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Config;
@@ -49,6 +50,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         ]
     );
 
+    private Config config = null!;
+
     private uint     originalSystemSoundValue;
     private bool     isSystemSoundMuted;
     private DateTime systemSoundMuteUntil = DateTime.MinValue;
@@ -57,6 +60,9 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     protected override void Init()
     {
+        config = Config.Load(this) ?? new();
+        TryRestorePendingSystemSound();
+
         AgentLobbyUpdateHook = AgentLobby.Instance()->VirtualTable->HookVFuncFromName("Update", (AgentLobby.Delegates.Update)AgentLobbyUpdateDetour);
         AgentLobbyUpdateHook.Enable();
         
@@ -138,6 +144,26 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         return IsPromptMatched(promptText->NodeText.ToString(), loginQueueErrorText);
     }
 
+    private void TryRestorePendingSystemSound()
+    {
+        if (!config.HasPendingSystemSoundRestore) return;
+
+        try
+        {
+            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out uint currentValue))
+                return;
+
+            if (currentValue == 0)
+                DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, config.OriginalSystemSoundValue);
+
+            ClearPendingSystemSoundRestore();
+        }
+        catch (Exception ex)
+        {
+            DLog.Warning("恢复上次异常退出前的系统音失败", ex);
+        }
+    }
+
     private void ExtendSystemSoundMute()
     {
         systemSoundMuteUntil = StandardTimeManager.Instance().Now + SystemSoundMuteDuration;
@@ -149,8 +175,11 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
             if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out originalSystemSoundValue))
                 return;
 
-            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
+            if (!TrySavePendingSystemSoundRestore(originalSystemSoundValue))
+                return;
+
             isSystemSoundMuted = true;
+            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
             FrameworkManager.Instance().Reg(OnUpdate, SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS);
         }
         catch (Exception ex)
@@ -172,9 +201,11 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     {
         if (!isSystemSoundMuted) return;
 
+        var isRestored = false;
         try
         {
             DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, originalSystemSoundValue);
+            isRestored = true;
         }
         catch (Exception ex)
         {
@@ -186,6 +217,46 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
             systemSoundMuteUntil = DateTime.MinValue;
 
             FrameworkManager.Instance().Unreg(OnUpdate);
+
+            if (isRestored)
+                ClearPendingSystemSoundRestore();
+        }
+    }
+
+    private bool TrySavePendingSystemSoundRestore(uint originalValue)
+    {
+        config.HasPendingSystemSoundRestore = true;
+        config.OriginalSystemSoundValue     = originalValue;
+
+        try
+        {
+            config.Save(this);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            config.HasPendingSystemSoundRestore = false;
+            config.OriginalSystemSoundValue     = 0;
+
+            DLog.Warning("保存系统音恢复状态失败", ex);
+            return false;
+        }
+    }
+
+    private void ClearPendingSystemSoundRestore()
+    {
+        if (!config.HasPendingSystemSoundRestore) return;
+
+        config.HasPendingSystemSoundRestore = false;
+        config.OriginalSystemSoundValue     = 0;
+
+        try
+        {
+            config.Save(this);
+        }
+        catch (Exception ex)
+        {
+            DLog.Warning("清理系统音恢复状态失败", ex);
         }
     }
 
@@ -228,6 +299,12 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     private static string NormalizePromptText(string text) =>
         text.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+
+    private class Config : ModuleConfig
+    {
+        public bool HasPendingSystemSoundRestore;
+        public uint OriginalSystemSoundValue;
+    }
 
     #region 常量
 

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -117,6 +117,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     {
         if (!isSystemSoundMuted) return;
 
+        // 手动取消排队会经过 SelectYesno, 需要在这里恢复 SelectOk 的 EnableFilter，否则游戏会跳过遮罩清理。
         var selectOk = DService.Instance().GameGUI.GetAddonByName("SelectOk").Address;
         if (selectOk == nint.Zero) return;
 

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -88,8 +88,15 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         agent->TemporaryLocked = false;
         AgentLobbyUpdateHook.Original(agent, deltaTime);
         lobbyUpdateStage = agent->LobbyUpdateStage;
-        if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE)
+
+        var isLoginQueueStage = lobbyUpdateStage == LOGIN_QUEUE_LOBBY_UPDATE_STAGE;
+        if (!isLoginQueueStage)
             isSelectOkFilterRestored = false;
+
+        if (isSystemSoundMuted && 
+            (!isLoginQueueStage || StandardTimeManager.Instance().Now >= systemSoundMuteUntil))
+            RestoreSystemSound();
+
         agent->TemporaryLocked = false;
     }
     
@@ -155,7 +162,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
             isSystemSoundMuted = true;
             DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
-            FrameworkManager.Instance().Reg(OnUpdate, SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS);
         }
         catch (Exception ex)
         {
@@ -164,12 +170,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
             DLog.Warning("临时关闭系统音失败", ex);
         }
-    }
-
-    private void OnUpdate(IFramework _)
-    {
-        if (isSystemSoundMuted && StandardTimeManager.Instance().Now >= systemSoundMuteUntil)
-            RestoreSystemSound();
     }
 
     private void RestoreSystemSound()
@@ -190,8 +190,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         {
             isSystemSoundMuted   = false;
             systemSoundMuteUntil = DateTime.MinValue;
-
-            FrameworkManager.Instance().Unreg(OnUpdate);
 
             if (isRestored)
                 ClearPendingSystemSoundRestore();
@@ -244,7 +242,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     #region 常量
 
     private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE         = 31;
-    private const int  SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS = 500;
 
     private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1000);
 

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -6,16 +6,14 @@ using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Config;
 using Dalamud.Hooking;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using Lumina.Excel.Sheets;
 using OmenTools.Dalamud;
 using OmenTools.Interop.Game;
+using OmenTools.Interop.Game.Helpers;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
-using OmenTools.Threading;
 
 namespace DailyRoutines.ModulesPublic;
 
@@ -55,7 +53,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private uint     originalSystemSoundValue;
     private bool     isSystemSoundMuted;
     private DateTime systemSoundMuteUntil = DateTime.MinValue;
-    private string   loginQueueErrorText  = string.Empty;
+    private byte     lobbyUpdateStage;
     private bool     isSelectOkFilterRestored;
 
     protected override void Init()
@@ -74,8 +72,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         
         loginFallbackPatch.Enable();
 
-        loginQueueErrorText = LoadLoginQueueErrorText();
-
         DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PreDraw, "SelectOk",    OnSelectOk);
         DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PreDraw, "SelectYesno", OnSelectYesno);
     }
@@ -85,14 +81,16 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectOk);
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectYesno);
         RestoreSystemSound();
-        loginQueueErrorText         = string.Empty;
-        isSelectOkFilterRestored    = false;
+        isSelectOkFilterRestored = false;
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)
     {
         agent->TemporaryLocked = false;
         AgentLobbyUpdateHook.Original(agent, deltaTime);
+        lobbyUpdateStage = agent->LobbyUpdateStage;
+        if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE)
+            isSelectOkFilterRestored = false;
         agent->TemporaryLocked = false;
     }
     
@@ -104,44 +102,24 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     private void OnSelectOk(AddonEvent _, AddonArgs args)
     {
+        if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE) return;
+
         var addon = (AtkUnitBase*)args.Addon.Address;
-
-        if (!IsLoginQueueErrorDialog(addon))
-            return;
-
         if (!isSelectOkFilterRestored)
             addon->EnableFilter = false;
 
-        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnSelectOkDraw", SYSTEM_SOUND_MUTE_THROTTLE_MS))
-            return;
-
-        isSelectOkFilterRestored = false;
         ExtendSystemSoundMute();
     }
 
     private void OnSelectYesno(AddonEvent _, AddonArgs args)
     {
-        if (!isSystemSoundMuted) return;
+        if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE) return;
 
-        // 手动取消排队会经过 SelectYesno, 需要在这里恢复 SelectOk 的 EnableFilter，否则游戏会跳过遮罩清理。
-        var selectOk = DService.Instance().GameGUI.GetAddonByName("SelectOk").Address;
-        if (selectOk == nint.Zero) return;
+        // 手动取消排队会经过 SelectYesno，需要在这里恢复 SelectOk 的 EnableFilter，否则游戏会跳过遮罩清理。
+        if (!AddonHelper.TryGetByName("SelectOk", out var selectOk)) return;
 
-        ((AtkUnitBase*)selectOk)->EnableFilter = true;
+        selectOk->EnableFilter = true;
         isSelectOkFilterRestored = true;
-    }
-
-    private bool IsLoginQueueErrorDialog(AtkUnitBase* selectOk)
-    {
-        if (selectOk == null || CharaSelect == null) return false;
-
-        if (!selectOk->IsAddonAndNodesReady()) return false;
-
-        var addon      = (AddonSelectOk*)selectOk;
-        var promptText = addon->PromptText;
-        if (promptText == null) return false;
-
-        return IsPromptMatched(promptText->NodeText.ToString(), loginQueueErrorText);
     }
 
     private void TryRestorePendingSystemSound()
@@ -260,46 +238,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         }
     }
 
-    private static string LoadLoginQueueErrorText()
-    {
-        try
-        {
-            return LuminaGetter.TryGetRow<Error>(LOGIN_QUEUE_ERROR_ROW_ID, out var row)
-                       ? GetFirstNonEmptyLine(row.Unknown0.ToString())
-                       : string.Empty;
-        }
-        catch (Exception ex)
-        {
-            DLog.Warning("加载登录排队错误文本失败", ex);
-            return string.Empty;
-        }
-    }
-
-    private static string GetFirstNonEmptyLine(string text)
-    {
-        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
-        {
-            var trimmed = line.Trim();
-            if (!string.IsNullOrWhiteSpace(trimmed))
-                return trimmed;
-        }
-
-        return string.Empty;
-    }
-
-    private static bool IsPromptMatched(string text, string prompt)
-    {
-        var normalizedText   = NormalizePromptText(text);
-        var normalizedPrompt = NormalizePromptText(prompt);
-
-        return !string.IsNullOrWhiteSpace(normalizedText)   &&
-               !string.IsNullOrWhiteSpace(normalizedPrompt) &&
-               normalizedText.Contains(normalizedPrompt, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string NormalizePromptText(string text) =>
-        text.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
-
     private class Config : ModuleConfig
     {
         public bool HasPendingSystemSoundRestore;
@@ -308,11 +246,10 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     #region 常量
 
-    private const uint LOGIN_QUEUE_ERROR_ROW_ID               = 13206;
-    private const int  SYSTEM_SOUND_MUTE_THROTTLE_MS          = 1_000;
+    private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE         = 31;
     private const int  SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS = 500;
 
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1_200);
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1000);
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -106,7 +106,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (!isFilterRestored)
             addon->EnableFilter = false;
 
-        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnSelectOkDraw", 250))
+        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnSelectOkDraw", SYSTEM_SOUND_MUTE_THROTTLE_MS))
             return;
 
         isFilterRestored = false;
@@ -151,7 +151,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
             DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
             isSystemSoundMuted = true;
-            FrameworkManager.Instance().Reg(OnUpdate, 250);
+            FrameworkManager.Instance().Reg(OnUpdate, SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS);
         }
         catch (Exception ex)
         {
@@ -232,7 +232,9 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     #region 常量
 
     private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(0.5);
+    private const int  SYSTEM_SOUND_MUTE_THROTTLE_MS = 1_000;
+    private const int  SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS = 500;
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1_200);
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -39,12 +39,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private static readonly CompSig             Timer1Sig = new("40 53 57 48 83 EC ?? 48 8B F9 41 8B D8");
     private                 Hook<TimerDelegate> Timer1Hook;
 
-    private uint     originalSystemSoundValue;
-    private bool     isSystemSoundMuted;
-    private DateTime systemSoundMuteUntil = DateTime.MinValue;
-    private string   loginQueueErrorText  = string.Empty;
-    private bool     isFilterRestored;
-
     private readonly MemoryPatch loginFallbackPatch = new
     (
         "48 81 BE ?? ?? ?? ?? ?? ?? ?? ?? 76",
@@ -54,6 +48,12 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
             0x76, 0x16                                // JBE rel8
         ]
     );
+
+    private uint     originalSystemSoundValue;
+    private bool     isSystemSoundMuted;
+    private DateTime systemSoundMuteUntil = DateTime.MinValue;
+    private string   loginQueueErrorText  = string.Empty;
+    private bool     isSelectOkFilterRestored;
 
     protected override void Init()
     {
@@ -79,8 +79,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectOk);
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectYesno);
         RestoreSystemSound();
-        loginQueueErrorText = string.Empty;
-        isFilterRestored    = false;
+        loginQueueErrorText         = string.Empty;
+        isSelectOkFilterRestored    = false;
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)
@@ -103,13 +103,13 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (!IsLoginQueueErrorDialog(addon))
             return;
 
-        if (!isFilterRestored)
+        if (!isSelectOkFilterRestored)
             addon->EnableFilter = false;
 
         if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnSelectOkDraw", SYSTEM_SOUND_MUTE_THROTTLE_MS))
             return;
 
-        isFilterRestored = false;
+        isSelectOkFilterRestored = false;
         ExtendSystemSoundMute();
     }
 
@@ -122,7 +122,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (selectOk == nint.Zero) return;
 
         ((AtkUnitBase*)selectOk)->EnableFilter = true;
-        isFilterRestored = true;
+        isSelectOkFilterRestored = true;
     }
 
     private bool IsLoginQueueErrorDialog(AtkUnitBase* selectOk)
@@ -231,9 +231,10 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     #region 常量
 
-    private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
-    private const int  SYSTEM_SOUND_MUTE_THROTTLE_MS = 1_000;
+    private const uint LOGIN_QUEUE_ERROR_ROW_ID               = 13206;
+    private const int  SYSTEM_SOUND_MUTE_THROTTLE_MS          = 1_000;
     private const int  SYSTEM_SOUND_RESTORE_CHECK_INTERVAL_MS = 500;
+
     private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1_200);
 
     #endregion

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -92,8 +92,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (!isLoginQueueStage)
             isSelectOkFilterRestored = false;
 
-        if (isSystemSoundMuted &&
-            (!isLoginQueueStage || StandardTimeManager.Instance().Now >= systemSoundMuteUntil))
+        if (isSystemSoundMuted && StandardTimeManager.Instance().Now >= systemSoundMuteUntil)
             RestoreSystemSound();
 
         agent->TemporaryLocked = false;
@@ -219,7 +218,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE        = 31;
 
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1000);
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1500);
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -9,8 +9,8 @@ using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using OmenTools.Dalamud;
+using OmenTools.Info.Game.Data;
 using OmenTools.Interop.Game;
-using OmenTools.Interop.Game.Helpers;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
@@ -116,7 +116,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE) return;
 
         // 手动取消排队会经过 SelectYesno，需要在这里恢复 SelectOk 的 EnableFilter，否则游戏会跳过遮罩清理。
-        if (!AddonHelper.TryGetByName("SelectOk", out var selectOk)) return;
+        var selectOk = SelectOK;
+        if (selectOk == null) return;
 
         selectOk->EnableFilter = true;
         isSelectOkFilterRestored = true;

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -232,7 +232,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     #region 常量
 
     private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(1.5);
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(0.5);
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -1,14 +1,20 @@
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Config;
 using Dalamud.Hooking;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using Lumina.Excel.Sheets;
 using OmenTools.Dalamud;
 using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
+using OmenTools.Threading;
 
 namespace DailyRoutines.ModulesPublic;
 
@@ -36,6 +42,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private uint     originalSystemSoundValue;
     private bool     isSystemSoundMuted;
     private DateTime systemSoundMuteUntil = DateTime.MinValue;
+    private string   loginQueueErrorText  = string.Empty;
+    private bool     isFilterRestored;
 
     private readonly MemoryPatch loginFallbackPatch = new
     (
@@ -59,12 +67,20 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         Timer1Hook.Enable();
         
         loginFallbackPatch.Enable();
+
+        loginQueueErrorText = LoadLoginQueueErrorText();
+
+        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PreDraw, "SelectOk",    OnSelectOk);
+        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PreDraw, "SelectYesno", OnSelectYesno);
     }
 
     protected override void Uninit()
     {
+        DService.Instance().AddonLifecycle.UnregisterListener(OnSelectOk);
+        DService.Instance().AddonLifecycle.UnregisterListener(OnSelectYesno);
         RestoreSystemSound();
-        FrameworkManager.Instance().Unreg(OnUpdate);
+        loginQueueErrorText = string.Empty;
+        isFilterRestored    = false;
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)
@@ -72,9 +88,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         agent->TemporaryLocked = false;
         AgentLobbyUpdateHook.Original(agent, deltaTime);
         agent->TemporaryLocked = false;
-
-        if (IsLoginQueueing(agent))
-            ExtendSystemSoundMute();
     }
     
     private byte Timer0Detour(void* timer, int intervalSecond, int retryCount) =>
@@ -83,8 +96,46 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private byte Timer1Detour(void* timer, int intervalSecond, int retryCount) =>
         Timer1Hook.Original(timer, 1, retryCount);
 
-    private bool IsLoginQueueing(AgentLobby* agent) =>
-        agent != null && CharaSelect != null && agent->QueuePosition > 0;
+    private void OnSelectOk(AddonEvent _, AddonArgs args)
+    {
+        var addon = (AtkUnitBase*)args.Addon.Address;
+
+        if (!IsLoginQueueErrorDialog(addon))
+            return;
+
+        if (!isFilterRestored)
+            addon->EnableFilter = false;
+
+        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnSelectOkDraw", 250))
+            return;
+
+        isFilterRestored = false;
+        ExtendSystemSoundMute();
+    }
+
+    private void OnSelectYesno(AddonEvent _, AddonArgs args)
+    {
+        if (!isSystemSoundMuted) return;
+
+        var selectOk = DService.Instance().GameGUI.GetAddonByName("SelectOk").Address;
+        if (selectOk == nint.Zero) return;
+
+        ((AtkUnitBase*)selectOk)->EnableFilter = true;
+        isFilterRestored = true;
+    }
+
+    private bool IsLoginQueueErrorDialog(AtkUnitBase* selectOk)
+    {
+        if (selectOk == null || CharaSelect == null) return false;
+
+        if (!selectOk->IsAddonAndNodesReady()) return false;
+
+        var addon      = (AddonSelectOk*)selectOk;
+        var promptText = addon->PromptText;
+        if (promptText == null) return false;
+
+        return IsPromptMatched(promptText->NodeText.ToString(), loginQueueErrorText);
+    }
 
     private void ExtendSystemSoundMute()
     {
@@ -130,15 +181,57 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         }
         finally
         {
-            FrameworkManager.Instance().Unreg(OnUpdate);
             isSystemSoundMuted   = false;
             systemSoundMuteUntil = DateTime.MinValue;
+
+            FrameworkManager.Instance().Unreg(OnUpdate);
         }
     }
 
+    private static string LoadLoginQueueErrorText()
+    {
+        try
+        {
+            return LuminaGetter.TryGetRow<Error>(LOGIN_QUEUE_ERROR_ROW_ID, out var row)
+                       ? GetFirstNonEmptyLine(row.Unknown0.ToString())
+                       : string.Empty;
+        }
+        catch (Exception ex)
+        {
+            DLog.Warning("加载登录排队错误文本失败", ex);
+            return string.Empty;
+        }
+    }
+
+    private static string GetFirstNonEmptyLine(string text)
+    {
+        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!string.IsNullOrWhiteSpace(trimmed))
+                return trimmed;
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsPromptMatched(string text, string prompt)
+    {
+        var normalizedText   = NormalizePromptText(text);
+        var normalizedPrompt = NormalizePromptText(prompt);
+
+        return !string.IsNullOrWhiteSpace(normalizedText)   &&
+               !string.IsNullOrWhiteSpace(normalizedPrompt) &&
+               normalizedText.Contains(normalizedPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePromptText(string text) =>
+        text.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+
     #region 常量
 
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(3);
+    private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(1.5);
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -9,7 +9,6 @@ using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
-using OmenTools.Threading;
 
 namespace DailyRoutines.ModulesPublic;
 

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -1,18 +1,16 @@
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
-using DailyRoutines.Extensions;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
-using Dalamud.Game.Config;
 using Dalamud.Hooking;
+using FFXIVClientStructs.FFXIV.Client.Sound;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using OmenTools.Dalamud;
+using InteropGenerator.Runtime;
 using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
-using OmenTools.OmenService;
 
 namespace DailyRoutines.ModulesPublic;
 
@@ -37,6 +35,19 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private static readonly CompSig             Timer1Sig = new("40 53 57 48 83 EC ?? 48 8B F9 41 8B D8");
     private                 Hook<TimerDelegate> Timer1Hook;
 
+    private static readonly CompSig                       PlaySystemSoundSig = new("E8 ?? ?? ?? ?? 48 0F BE 46 ?? 41 B1");
+    private delegate        SoundData*                    PlaySystemSoundDelegate
+    (
+        SoundManager*       soundManager,
+        CStringPointer      path,
+        float               volume,
+        uint                soundNumber,
+        uint                fadeInDuration,
+        bool                autoRelease,
+        SoundVolumeCategory volumeCategory
+    );
+    private                 Hook<PlaySystemSoundDelegate> PlaySystemSoundHook;
+
     private readonly MemoryPatch loginFallbackPatch = new
     (
         "48 81 BE ?? ?? ?? ?? ?? ?? ?? ?? 76",
@@ -47,26 +58,22 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         ]
     );
 
-    private Config config = null!;
-
-    private bool     isSystemSoundMuted;
-    private DateTime systemSoundMuteUntil = DateTime.MinValue;
     private byte     lobbyUpdateStage;
+    private long     systemSoundFilterUntil;
     private bool     isSelectOkFilterRestored;
 
     protected override void Init()
     {
-        config = Config.Load(this) ?? new();
-        TryRestorePendingSystemSound();
-
         AgentLobbyUpdateHook = AgentLobby.Instance()->VirtualTable->HookVFuncFromName("Update", (AgentLobby.Delegates.Update)AgentLobbyUpdateDetour);
         AgentLobbyUpdateHook.Enable();
         
-        Timer0Hook = Timer0Sig.GetHook<TimerDelegate>(Timer0Detour);
-        Timer1Hook = Timer1Sig.GetHook<TimerDelegate>(Timer1Detour);
+        Timer0Hook          = Timer0Sig.GetHook<TimerDelegate>(Timer0Detour);
+        Timer1Hook          = Timer1Sig.GetHook<TimerDelegate>(Timer1Detour);
+        PlaySystemSoundHook = PlaySystemSoundSig.GetHook<PlaySystemSoundDelegate>(PlaySystemSoundDetour);
         
         Timer0Hook.Enable();
         Timer1Hook.Enable();
+        PlaySystemSoundHook.Enable();
         
         loginFallbackPatch.Enable();
 
@@ -78,7 +85,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     {
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectOk);
         DService.Instance().AddonLifecycle.UnregisterListener(OnSelectYesno);
-        RestoreSystemSound();
         isSelectOkFilterRestored = false;
     }
 
@@ -86,14 +92,14 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     {
         agent->TemporaryLocked = false;
         AgentLobbyUpdateHook.Original(agent, deltaTime);
+
         lobbyUpdateStage = agent->LobbyUpdateStage;
 
         var isLoginQueueStage = lobbyUpdateStage == LOGIN_QUEUE_LOBBY_UPDATE_STAGE;
-        if (!isLoginQueueStage)
+        if (isLoginQueueStage)
+            systemSoundFilterUntil = Environment.TickCount64 + LOGIN_QUEUE_SOUND_FILTER_STICKY_MS;
+        else
             isSelectOkFilterRestored = false;
-
-        if (isSystemSoundMuted && StandardTimeManager.Instance().Now >= systemSoundMuteUntil)
-            RestoreSystemSound();
 
         agent->TemporaryLocked = false;
     }
@@ -104,6 +110,23 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private byte Timer1Detour(void* timer, int intervalSecond, int retryCount) =>
         Timer1Hook.Original(timer, 1, retryCount);
 
+    private SoundData* PlaySystemSoundDetour
+    (
+        SoundManager*       soundManager,
+        CStringPointer      path,
+        float               volume,
+        uint                soundNumber,
+        uint                fadeInDuration,
+        bool                autoRelease,
+        SoundVolumeCategory volumeCategory
+    )
+    {
+        if (Environment.TickCount64 < systemSoundFilterUntil)
+            return null;
+
+        return PlaySystemSoundHook.Original(soundManager, path, volume, soundNumber, fadeInDuration, autoRelease, volumeCategory);
+    }
+
     private void OnSelectOk(AddonEvent _, AddonArgs args)
     {
         if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE) return;
@@ -111,8 +134,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         var addon = (AtkUnitBase*)args.Addon.Address;
         if (!isSelectOkFilterRestored)
             addon->EnableFilter = false;
-
-        ExtendSystemSoundMute();
     }
 
     private void OnSelectYesno(AddonEvent _, AddonArgs args)
@@ -124,101 +145,10 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         isSelectOkFilterRestored = true;
     }
 
-    private void TryRestorePendingSystemSound()
-    {
-        if (!config.HasPendingSystemSoundRestore) return;
-
-        try
-        {
-            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out uint currentValue))
-                return;
-
-            if (currentValue == 0)
-                DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, config.OriginalSystemSoundValue);
-
-            config.HasPendingSystemSoundRestore = false;
-            config.OriginalSystemSoundValue     = 0;
-            config.Save(this);
-        }
-        catch (Exception ex)
-        {
-            DLog.Warning("恢复上次异常退出前的系统音失败", ex);
-        }
-    }
-
-    private void ExtendSystemSoundMute()
-    {
-        systemSoundMuteUntil = StandardTimeManager.Instance().Now + SystemSoundMuteDuration;
-
-        if (isSystemSoundMuted) return;
-
-        try
-        {
-            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out uint originalSystemSoundValue))
-                return;
-
-            config.HasPendingSystemSoundRestore = true;
-            config.OriginalSystemSoundValue     = originalSystemSoundValue;
-            config.Save(this);
-
-            isSystemSoundMuted = true;
-            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
-        }
-        catch (Exception ex)
-        {
-            if (isSystemSoundMuted)
-                RestoreSystemSound();
-            else
-            {
-                config.HasPendingSystemSoundRestore = false;
-                config.OriginalSystemSoundValue     = 0;
-                config.Save(this);
-            }
-
-            DLog.Warning("临时关闭系统音失败", ex);
-        }
-    }
-
-    private void RestoreSystemSound()
-    {
-        if (!isSystemSoundMuted) return;
-
-        try
-        {
-            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, config.OriginalSystemSoundValue);
-        }
-        catch (Exception ex)
-        {
-            DLog.Warning("恢复系统音失败", ex);
-            return;
-        }
-
-        isSystemSoundMuted   = false;
-        systemSoundMuteUntil = DateTime.MinValue;
-
-        try
-        {
-            config.HasPendingSystemSoundRestore = false;
-            config.OriginalSystemSoundValue     = 0;
-            config.Save(this);
-        }
-        catch (Exception ex)
-        {
-            DLog.Warning("清理系统音恢复状态失败", ex);
-        }
-    }
-
-    private class Config : ModuleConfig
-    {
-        public bool HasPendingSystemSoundRestore;
-        public uint OriginalSystemSoundValue;
-    }
-
     #region 常量
 
-    private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE        = 31;
-
-    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1500);
+    private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE     = 31;
+    private const int  LOGIN_QUEUE_SOUND_FILTER_STICKY_MS = 1_000;
 
     #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -9,7 +9,6 @@ using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using OmenTools.Dalamud;
-using OmenTools.Info.Game.Data;
 using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
@@ -116,10 +115,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (lobbyUpdateStage != LOGIN_QUEUE_LOBBY_UPDATE_STAGE) return;
 
         // 手动取消排队会经过 SelectYesno，需要在这里恢复 SelectOk 的 EnableFilter，否则游戏会跳过遮罩清理。
-        var selectOk = SelectOK;
-        if (selectOk == null) return;
-
-        selectOk->EnableFilter = true;
+        SelectOK->EnableFilter = true;
         isSelectOkFilterRestored = true;
     }
 

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -1,11 +1,20 @@
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Game.Config;
 using Dalamud.Hooking;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using Lumina.Excel.Sheets;
+using OmenTools.Dalamud;
 using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
+using OmenTools.OmenService;
+using OmenTools.Threading;
 
 namespace DailyRoutines.ModulesPublic;
 
@@ -30,6 +39,11 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private static readonly CompSig             Timer1Sig = new("40 53 57 48 83 EC ?? 48 8B F9 41 8B D8");
     private                 Hook<TimerDelegate> Timer1Hook;
 
+    private uint     originalSystemSoundValue;
+    private bool     isSystemSoundMuted;
+    private DateTime systemSoundMuteUntil = DateTime.MinValue;
+    private string   loginQueueErrorText  = string.Empty;
+
     private readonly MemoryPatch loginFallbackPatch = new
     (
         "48 81 BE ?? ?? ?? ?? ?? ?? ?? ?? 76",
@@ -52,6 +66,17 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         Timer1Hook.Enable();
         
         loginFallbackPatch.Enable();
+
+        loginQueueErrorText = LoadLoginQueueErrorText();
+        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PostDraw, "SelectOk", OnAddon);
+    }
+
+    protected override void Uninit()
+    {
+        DService.Instance().AddonLifecycle.UnregisterListener(OnAddon);
+        RestoreSystemSound();
+        FrameworkManager.Instance().Unreg(OnUpdate);
+        loginQueueErrorText = string.Empty;
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)
@@ -66,4 +91,124 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     private byte Timer1Detour(void* timer, int intervalSecond, int retryCount) =>
         Timer1Hook.Original(timer, 1, retryCount);
+
+    private void OnAddon(AddonEvent _, AddonArgs args)
+    {
+        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnAddonDraw", 250))
+            return;
+
+        if (IsLoginQueueErrorDialog((AtkUnitBase*)args.Addon.Address))
+            ExtendSystemSoundMute();
+    }
+
+    private bool IsLoginQueueErrorDialog(AtkUnitBase* selectOk)
+    {
+        if (selectOk == null || CharaSelect == null) return false;
+
+        if (!selectOk->IsAddonAndNodesReady()) return false;
+
+        var addon      = (AddonSelectOk*)selectOk;
+        var promptText = addon->PromptText;
+        if (promptText == null) return false;
+
+        return IsPromptMatched(promptText->NodeText.ToString(), loginQueueErrorText);
+    }
+
+    private void ExtendSystemSoundMute()
+    {
+        systemSoundMuteUntil = StandardTimeManager.Instance().Now + SystemSoundMuteDuration;
+
+        if (isSystemSoundMuted) return;
+
+        try
+        {
+            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out originalSystemSoundValue))
+                return;
+
+            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
+            isSystemSoundMuted = true;
+            FrameworkManager.Instance().Reg(OnUpdate, 250);
+        }
+        catch (Exception ex)
+        {
+            if (isSystemSoundMuted)
+                RestoreSystemSound();
+
+            DLog.Warning("临时关闭系统音失败", ex);
+        }
+    }
+
+    private void OnUpdate(IFramework _)
+    {
+        if (isSystemSoundMuted && StandardTimeManager.Instance().Now >= systemSoundMuteUntil)
+            RestoreSystemSound();
+    }
+
+    private void RestoreSystemSound()
+    {
+        if (!isSystemSoundMuted) return;
+
+        try
+        {
+            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, originalSystemSoundValue);
+        }
+        catch (Exception ex)
+        {
+            DLog.Warning("恢复系统音失败", ex);
+        }
+        finally
+        {
+            FrameworkManager.Instance().Unreg(OnUpdate);
+            isSystemSoundMuted   = false;
+            systemSoundMuteUntil = DateTime.MinValue;
+        }
+    }
+
+    private static string LoadLoginQueueErrorText()
+    {
+        try
+        {
+            // Error 13206 的后续行包含动态排队人数, 这里只取首个稳定提示行。
+            return LuminaGetter.TryGetRow<Error>(LOGIN_QUEUE_ERROR_ROW_ID, out var row)
+                       ? GetFirstNonEmptyLine(row.Unknown0.ToString())
+                       : string.Empty;
+        }
+        catch (Exception ex)
+        {
+            DLog.Warning("加载登录排队错误文本失败", ex);
+            return string.Empty;
+        }
+    }
+
+    private static string GetFirstNonEmptyLine(string text)
+    {
+        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!string.IsNullOrWhiteSpace(trimmed))
+                return trimmed;
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsPromptMatched(string text, string prompt)
+    {
+        var normalizedText   = NormalizePromptText(text);
+        var normalizedPrompt = NormalizePromptText(prompt);
+
+        return !string.IsNullOrWhiteSpace(normalizedText)   &&
+               !string.IsNullOrWhiteSpace(normalizedPrompt) &&
+               normalizedText.Contains(normalizedPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePromptText(string text) =>
+        text.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+
+    #region 常量
+
+    private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
+    private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(3);
+
+    #endregion
 }

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -1,14 +1,9 @@
 using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
-using Dalamud.Game.Addon.Lifecycle;
-using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Config;
 using Dalamud.Hooking;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using FFXIVClientStructs.FFXIV.Component.GUI;
-using Lumina.Excel.Sheets;
 using OmenTools.Dalamud;
 using OmenTools.Interop.Game;
 using OmenTools.Interop.Game.Lumina;
@@ -42,7 +37,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private uint     originalSystemSoundValue;
     private bool     isSystemSoundMuted;
     private DateTime systemSoundMuteUntil = DateTime.MinValue;
-    private string   loginQueueErrorText  = string.Empty;
 
     private readonly MemoryPatch loginFallbackPatch = new
     (
@@ -66,17 +60,12 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         Timer1Hook.Enable();
         
         loginFallbackPatch.Enable();
-
-        loginQueueErrorText = LoadLoginQueueErrorText();
-        DService.Instance().AddonLifecycle.RegisterListener(AddonEvent.PostDraw, "SelectOk", OnAddon);
     }
 
     protected override void Uninit()
     {
-        DService.Instance().AddonLifecycle.UnregisterListener(OnAddon);
         RestoreSystemSound();
         FrameworkManager.Instance().Unreg(OnUpdate);
-        loginQueueErrorText = string.Empty;
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)
@@ -84,6 +73,9 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         agent->TemporaryLocked = false;
         AgentLobbyUpdateHook.Original(agent, deltaTime);
         agent->TemporaryLocked = false;
+
+        if (IsLoginQueueing(agent))
+            ExtendSystemSoundMute();
     }
     
     private byte Timer0Detour(void* timer, int intervalSecond, int retryCount) =>
@@ -92,27 +84,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     private byte Timer1Detour(void* timer, int intervalSecond, int retryCount) =>
         Timer1Hook.Original(timer, 1, retryCount);
 
-    private void OnAddon(AddonEvent _, AddonArgs args)
-    {
-        if (!Throttler.Shared.Throttle("AutoIgnoreLoginLock-OnAddonDraw", 250))
-            return;
-
-        if (IsLoginQueueErrorDialog((AtkUnitBase*)args.Addon.Address))
-            ExtendSystemSoundMute();
-    }
-
-    private bool IsLoginQueueErrorDialog(AtkUnitBase* selectOk)
-    {
-        if (selectOk == null || CharaSelect == null) return false;
-
-        if (!selectOk->IsAddonAndNodesReady()) return false;
-
-        var addon      = (AddonSelectOk*)selectOk;
-        var promptText = addon->PromptText;
-        if (promptText == null) return false;
-
-        return IsPromptMatched(promptText->NodeText.ToString(), loginQueueErrorText);
-    }
+    private bool IsLoginQueueing(AgentLobby* agent) =>
+        agent != null && CharaSelect != null && agent->QueuePosition > 0;
 
     private void ExtendSystemSoundMute()
     {
@@ -164,50 +137,8 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         }
     }
 
-    private static string LoadLoginQueueErrorText()
-    {
-        try
-        {
-            // Error 13206 的后续行包含动态排队人数, 这里只取首个稳定提示行。
-            return LuminaGetter.TryGetRow<Error>(LOGIN_QUEUE_ERROR_ROW_ID, out var row)
-                       ? GetFirstNonEmptyLine(row.Unknown0.ToString())
-                       : string.Empty;
-        }
-        catch (Exception ex)
-        {
-            DLog.Warning("加载登录排队错误文本失败", ex);
-            return string.Empty;
-        }
-    }
-
-    private static string GetFirstNonEmptyLine(string text)
-    {
-        foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
-        {
-            var trimmed = line.Trim();
-            if (!string.IsNullOrWhiteSpace(trimmed))
-                return trimmed;
-        }
-
-        return string.Empty;
-    }
-
-    private static bool IsPromptMatched(string text, string prompt)
-    {
-        var normalizedText   = NormalizePromptText(text);
-        var normalizedPrompt = NormalizePromptText(prompt);
-
-        return !string.IsNullOrWhiteSpace(normalizedText)   &&
-               !string.IsNullOrWhiteSpace(normalizedPrompt) &&
-               normalizedText.Contains(normalizedPrompt, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string NormalizePromptText(string text) =>
-        text.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
-
     #region 常量
 
-    private const uint LOGIN_QUEUE_ERROR_ROW_ID = 13206;
     private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromSeconds(3);
 
     #endregion

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -49,7 +49,6 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     private Config config = null!;
 
-    private uint     originalSystemSoundValue;
     private bool     isSystemSoundMuted;
     private DateTime systemSoundMuteUntil = DateTime.MinValue;
     private byte     lobbyUpdateStage;
@@ -93,7 +92,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         if (!isLoginQueueStage)
             isSelectOkFilterRestored = false;
 
-        if (isSystemSoundMuted && 
+        if (isSystemSoundMuted &&
             (!isLoginQueueStage || StandardTimeManager.Instance().Now >= systemSoundMuteUntil))
             RestoreSystemSound();
 
@@ -138,7 +137,9 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
             if (currentValue == 0)
                 DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, config.OriginalSystemSoundValue);
 
-            ClearPendingSystemSoundRestore();
+            config.HasPendingSystemSoundRestore = false;
+            config.OriginalSystemSoundValue     = 0;
+            config.Save(this);
         }
         catch (Exception ex)
         {
@@ -154,11 +155,12 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
         try
         {
-            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out originalSystemSoundValue))
+            if (!DService.Instance().GameConfig.TryGet(SystemConfigOption.SoundSystem, out uint originalSystemSoundValue))
                 return;
 
-            if (!TrySavePendingSystemSoundRestore(originalSystemSoundValue))
-                return;
+            config.HasPendingSystemSoundRestore = true;
+            config.OriginalSystemSoundValue     = originalSystemSoundValue;
+            config.Save(this);
 
             isSystemSoundMuted = true;
             DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, 0u);
@@ -167,6 +169,12 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         {
             if (isSystemSoundMuted)
                 RestoreSystemSound();
+            else
+            {
+                config.HasPendingSystemSoundRestore = false;
+                config.OriginalSystemSoundValue     = 0;
+                config.Save(this);
+            }
 
             DLog.Warning("临时关闭系统音失败", ex);
         }
@@ -176,55 +184,23 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
     {
         if (!isSystemSoundMuted) return;
 
-        var isRestored = false;
         try
         {
-            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, originalSystemSoundValue);
-            isRestored = true;
+            DService.Instance().GameConfig.Set(SystemConfigOption.SoundSystem, config.OriginalSystemSoundValue);
         }
         catch (Exception ex)
         {
             DLog.Warning("恢复系统音失败", ex);
+            return;
         }
-        finally
-        {
-            isSystemSoundMuted   = false;
-            systemSoundMuteUntil = DateTime.MinValue;
 
-            if (isRestored)
-                ClearPendingSystemSoundRestore();
-        }
-    }
-
-    private bool TrySavePendingSystemSoundRestore(uint originalValue)
-    {
-        config.HasPendingSystemSoundRestore = true;
-        config.OriginalSystemSoundValue     = originalValue;
+        isSystemSoundMuted   = false;
+        systemSoundMuteUntil = DateTime.MinValue;
 
         try
-        {
-            config.Save(this);
-            return true;
-        }
-        catch (Exception ex)
         {
             config.HasPendingSystemSoundRestore = false;
             config.OriginalSystemSoundValue     = 0;
-
-            DLog.Warning("保存系统音恢复状态失败", ex);
-            return false;
-        }
-    }
-
-    private void ClearPendingSystemSoundRestore()
-    {
-        if (!config.HasPendingSystemSoundRestore) return;
-
-        config.HasPendingSystemSoundRestore = false;
-        config.OriginalSystemSoundValue     = 0;
-
-        try
-        {
             config.Save(this);
         }
         catch (Exception ex)
@@ -241,7 +217,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
 
     #region 常量
 
-    private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE         = 31;
+    private const byte LOGIN_QUEUE_LOBBY_UPDATE_STAGE        = 31;
 
     private static readonly TimeSpan SystemSoundMuteDuration = TimeSpan.FromMilliseconds(1000);
 


### PR DESCRIPTION
优化 `AutoIgnoreLoginLock` 在登录排队时对 `SelectOk` 对话框的处理，减少模块原功能带来的副作用：登录排队对话框反复出现和消失造成的画面闪烁与系统音效。  
  
## 主要改动
不再匹配 `SelectOk` 的文本内容，改为基于 `AgentLobby.LobbyUpdateStage` 判断登录排队状态，仅在登录排队状态时处理：  
  
- **屏蔽音效：**  
使用 `PlaySystemSound` `Hook` 拦截登录排队期间的系统音播放（不再修改游戏系统音配置），以静音重复的系统音音效。

- **解决画面亮度闪烁：**  
登录排队期间 `SelectOk` 存在时，将 `EnableFilter` 设为 `false`，避免在其短暂消失时，画面遮罩和交互遮罩被游戏清理而造成画面闪烁。  
  
- **恢复：**  
  手动取消登录排队时会经过 `SelectYesno`，在此时恢复 `SelectOk.EnableFilter`，来避免遮罩清理被跳过。  
  登录成功时，即使没有手动恢复 `SelectOk.EnableFilter`，遮罩也会由游戏正常清理。  
  系统音的静音不再通过修改游戏配置实现，因此不需要对系统音静音做额外的恢复。

## 测试
- 改动前的模块原功能正常起效。
- 对应登录排队提示的 `SelectOk` 出现时，能保持遮罩并屏蔽系统音音效。
- 成功登录后，画面正常无遮罩，系统音正常，界面交互和角色操控无异常。
- 登录排队期间手动取消后，遮罩能被游戏正常清理，系统音正常。
