### PR TITLE
fea: 完善 AutoHideGameObjects 模块的玩家隐藏规则与配置体验

### DIFF
--- a/System/AutoHideGameObjects.cs
+++ b/System/AutoHideGameObjects.cs
@@ -8,6 +8,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
+using System.Numerics;
 using BattleNpcSubKind = Dalamud.Game.ClientState.Objects.Enums.BattleNpcSubKind;
 using ObjectKind = FFXIVClientStructs.FFXIV.Client.Game.Object.ObjectKind;
 
@@ -19,7 +20,6 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private const int   TARGETING_ME_PLAYER_KEEP_MS    = 60_000;
     private const int   RECENT_TARGET_PLAYER_KEEP_MS   = 30_000;
     private const byte  RECRUITING_ONLINE_STATUS_ID    = 26;  // 队员招募中
-
     public override ModuleInfo Info { get; } = new()
     {
         Title       = Lang.Get("AutoHideGameObjectsTitle"),
@@ -32,6 +32,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private                 Hook<UpdateObjectArraysDelegate> UpdateObjectArraysHook;
 
     private Config config = null!;
+    private bool showKeepRuleDebug;
 
     private readonly Dictionary<nint, HiddenObjectRecord> processedObjects          = [];
     private readonly Dictionary<ulong, long>              targetingMePlayers        = [];
@@ -124,6 +125,12 @@ public unsafe class AutoHideGameObjects : ModuleBase
                     changed |= Checkbox("AutoHideGameObjects-KeepPlayersTargetingMe",
                                         ref defaultConfig.KeepPlayersTargetingMe,
                                         "AutoHideGameObjects-KeepPlayersTargetingMeHelp");
+
+                    // 调试开关默认关闭；开启后只影响配置界面的调试展示，不参与隐藏逻辑判断
+                    ImGui.Checkbox("Debug###AutoHideGameObjectsShowKeepRuleDebug", ref showKeepRuleDebug);
+
+                    if (showKeepRuleDebug)
+                        DrawKeepRuleDebugUI();
                 }
             }
 
@@ -142,6 +149,102 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         if (changed)
             SaveConfigAndRefresh();
+    }
+
+    // 调试面板
+    private void DrawKeepRuleDebugUI()
+    {
+        ImGui.TextUnformatted
+        (
+            $"processedObjects={processedObjects.Count}, " +
+            $"objectsHiddenThisScan={objectsHiddenThisScan.Count}, " +
+            $"nearbyKeptPlayers={nearbyKeptPlayers.Count}, " +
+            $"recentTargetPlayers={recentTargetPlayers.Count}, " +
+            $"targetingMePlayers={targetingMePlayers.Count}"
+        );
+
+        var tableSize = new Vector2(-1f, ImGui.GetTextLineHeightWithSpacing() * 12f);
+        using var table = ImRaii.Table
+        (
+            "###AutoHideGameObjectsKeepRuleDebugTable",
+            6,
+            ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY,
+            tableSize
+        );
+
+        if (!table)
+            return;
+
+        ImGui.TableSetupColumn("Rule",     ImGuiTableColumnFlags.WidthFixed,   120f);
+        ImGui.TableSetupColumn("Player",   ImGuiTableColumnFlags.WidthStretch, 1f);
+        ImGui.TableSetupColumn("PlayerID", ImGuiTableColumnFlags.WidthFixed,   150f);
+        ImGui.TableSetupColumn("Remain",   ImGuiTableColumnFlags.WidthFixed,   70f);
+        ImGui.TableSetupColumn("Distance", ImGuiTableColumnFlags.WidthFixed,   70f);
+        ImGui.TableSetupColumn("TargetID", ImGuiTableColumnFlags.WidthFixed,   150f);
+        ImGui.TableHeadersRow();
+
+        var now = Environment.TickCount64;
+
+        foreach (var (playerID, expireTime) in recentTargetPlayers.OrderBy(x => x.Value))
+            DrawKeepRuleDebugRow("Target/Focus", playerID, expireTime, now);
+
+        foreach (var (playerID, expireTime) in targetingMePlayers.OrderBy(x => x.Value))
+            DrawKeepRuleDebugRow("Targeting me", playerID, expireTime, now);
+
+        foreach (var playerID in nearbyKeptPlayers.Order())
+            DrawKeepRuleDebugRow("Nearby", playerID, null, now);
+
+        if (config.DefaultConfig.KeepRecruitingPlayers)
+            DrawRecruitingPlayersDebugRows();
+    }
+
+    private void DrawRecruitingPlayersDebugRows()
+    {
+        var manager = GameObjectManager.Instance();
+        if (manager == null)
+            return;
+
+        for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+        {
+            if (index > 200)
+                break;
+
+            var gameObject = manager->Objects.IndexSorted[index].Value;
+            if (!IsPlayerObject(gameObject, (uint)index))
+                continue;
+
+            var player = (BattleChara*)gameObject;
+            if (player->OnlineStatus != RECRUITING_ONLINE_STATUS_ID)
+                continue;
+
+            var playerID = GetPlayerTrackingID(player);
+            if (playerID != 0)
+                DrawKeepRuleDebugRow("Recruiting", playerID, null, Environment.TickCount64);
+        }
+    }
+
+    private static void DrawKeepRuleDebugRow(string rule, ulong playerID, long? expireTime, long now)
+    {
+        TryFindPlayerByTrackingID(playerID, out var player);
+
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(rule);
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugPlayerName(player));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(playerID.ToString());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugRemainTimeText(expireTime, now));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugDistanceText(player));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugTargetIDText(player));
     }
 
     private void* UpdateObjectArraysDetour(GameObjectManager* objectManager)
@@ -453,6 +556,68 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
     private static ulong GetLocalPlayerGameObjectID() =>
         LocalPlayerState.Object?.GameObjectID ?? 0;
+
+    private static bool TryFindPlayerByTrackingID(ulong playerID, out BattleChara* player)
+    {
+        player = null;
+
+        var manager = GameObjectManager.Instance();
+        if (manager == null || playerID == 0)
+            return false;
+
+        for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+        {
+            if (index > 200)
+                break;
+
+            var gameObject = manager->Objects.IndexSorted[index].Value;
+            if (!IsPlayerObject(gameObject, (uint)index))
+                continue;
+
+            var currentPlayer = (BattleChara*)gameObject;
+            if (GetPlayerTrackingID(currentPlayer) != playerID)
+                continue;
+
+            player = currentPlayer;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string GetDebugPlayerName(BattleChara* player) =>
+        player == null || string.IsNullOrWhiteSpace(((GameObject*)player)->NameString)
+            ? "(not in object table)"
+            : ((GameObject*)player)->NameString;
+
+    private static string GetDebugRemainTimeText(long? expireTime, long now)
+    {
+        if (expireTime == null)
+            return "-";
+
+        var remainMs = Math.Max(0, expireTime.Value - now);
+        return $"{remainMs / 1000f:F1}s";
+    }
+
+    private static string GetDebugDistanceText(BattleChara* player) =>
+        player == null
+            ? "-"
+            : $"{LocalPlayerState.DistanceTo3D(player->Position):F1}m";
+
+    private static string GetDebugTargetIDText(BattleChara* player)
+    {
+        if (player == null)
+            return "-";
+
+        var targetID      = (ulong)player->GetTargetId();
+        var localPlayerID = GetLocalPlayerGameObjectID();
+        if (targetID == 0 || targetID == 0xE0000000)
+            return "No target";
+
+        return localPlayerID != 0 && targetID == localPlayerID
+                   ? $"{targetID} (me)"
+                   : targetID.ToString();
+    }
 
     private static bool IsPlayerObject(GameObject* gameObject, uint index) =>
         gameObject             != null &&

--- a/System/AutoHideGameObjects.cs
+++ b/System/AutoHideGameObjects.cs
@@ -2,6 +2,10 @@ using DailyRoutines.Common.Module.Abstractions;
 using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
 using DailyRoutines.Extensions;
+using Dalamud.Game.Chat;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.Enums;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
@@ -19,6 +23,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private const float NEARBY_PLAYER_RANGE_HYSTERESIS = 1.5f;
     private const int   TARGETING_ME_PLAYER_KEEP_MS    = 60_000;
     private const int   RECENT_TARGET_PLAYER_KEEP_MS   = 30_000;
+    private const int   RECENT_CHAT_PLAYER_KEEP_MS     = 300_000;
     private const byte  RECRUITING_ONLINE_STATUS_ID    = 26;  // 队员招募中
     public override ModuleInfo Info { get; } = new()
     {
@@ -34,9 +39,11 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private Config config = null!;
     private bool showKeepRuleDebug;
 
+    private readonly Lock                                 recentChatPlayersLock     = new();
     private readonly Dictionary<nint, HiddenObjectRecord> processedObjects          = [];
     private readonly Dictionary<ulong, long>              targetingMePlayers        = [];
     private readonly Dictionary<ulong, long>              recentTargetPlayers       = [];
+    private readonly Dictionary<string, long>             recentChatPlayers         = [];
     private readonly HashSet<ulong>                       nearbyKeptPlayers         = [];
     private readonly HashSet<nint>                        objectsHiddenThisScan     = [];
     private readonly HashSet<ulong>                       nearbyPlayersSeenThisScan = [];
@@ -47,12 +54,14 @@ public unsafe class AutoHideGameObjects : ModuleBase
     {
         TaskHelper ??= new() { TimeoutMS = 30_000 };
         config = Config.Load(this) ?? new();
+        MigrateConfig();
 
         UpdateObjectArraysHook ??= UpdateObjectArraysSig.GetHook<UpdateObjectArraysDelegate>(UpdateObjectArraysDetour);
         UpdateObjectArraysHook.Enable();
 
         UpdateAllObjects(GameObjectManager.Instance());
 
+        DService.Instance().Chat.ChatMessage += OnChatMessage;
         DService.Instance().ClientState.TerritoryChanged += OnZoneChanged;
         FrameworkManager.Instance().Reg(OnUpdate, 1_000);
     }
@@ -60,6 +69,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
     protected override void Uninit()
     {
         FrameworkManager.Instance().Unreg(OnUpdate);
+        DService.Instance().Chat.ChatMessage -= OnChatMessage;
         DService.Instance().ClientState.TerritoryChanged -= OnZoneChanged;
 
         ResetAllObjects();
@@ -126,7 +136,10 @@ public unsafe class AutoHideGameObjects : ModuleBase
                                         ref defaultConfig.KeepPlayersTargetingMe,
                                         "AutoHideGameObjects-KeepPlayersTargetingMeHelp");
 
-                    // 调试开关默认关闭；开启后只影响配置界面的调试展示，不参与隐藏逻辑判断
+                    changed |= Checkbox("AutoHideGameObjects-KeepRecentChatPlayers",
+                                        ref defaultConfig.KeepRecentChatPlayers,
+                                        "AutoHideGameObjects-KeepRecentChatPlayersHelp");
+
                     ImGui.Checkbox("Debug###AutoHideGameObjectsShowKeepRuleDebug", ref showKeepRuleDebug);
 
                     if (showKeepRuleDebug)
@@ -141,6 +154,14 @@ public unsafe class AutoHideGameObjects : ModuleBase
             changed |= Checkbox("AutoHideGameObjects-HidePet",
                                 ref defaultConfig.HidePet,
                                 "AutoHideGameObjects-HidePetHelp");
+
+            changed |= Checkbox("AutoHideGameObjects-HideCompanion",
+                                ref defaultConfig.HideCompanion,
+                                "AutoHideGameObjects-HideCompanionHelp");
+
+            changed |= Checkbox("AutoHideGameObjects-HideOrnament",
+                                ref defaultConfig.HideOrnament,
+                                "AutoHideGameObjects-HideOrnamentHelp");
 
             changed |= Checkbox("AutoHideGameObjects-HideChocobo",
                                 ref defaultConfig.HideChocobo,
@@ -160,7 +181,8 @@ public unsafe class AutoHideGameObjects : ModuleBase
             $"objectsHiddenThisScan={objectsHiddenThisScan.Count}, " +
             $"nearbyKeptPlayers={nearbyKeptPlayers.Count}, " +
             $"recentTargetPlayers={recentTargetPlayers.Count}, " +
-            $"targetingMePlayers={targetingMePlayers.Count}"
+            $"targetingMePlayers={targetingMePlayers.Count}, " +
+            $"recentChatPlayers={GetRecentChatPlayerCount()}"
         );
 
         var tableSize = new Vector2(-1f, ImGui.GetTextLineHeightWithSpacing() * 12f);
@@ -194,8 +216,35 @@ public unsafe class AutoHideGameObjects : ModuleBase
         foreach (var playerID in nearbyKeptPlayers.Order())
             DrawKeepRuleDebugRow("Nearby", playerID, null, now);
 
+        foreach (var (playerName, expireTime) in GetRecentChatPlayerSnapshot().OrderBy(x => x.Value))
+            DrawRecentChatPlayerDebugRow(playerName, expireTime, now);
+
         if (config.DefaultConfig.KeepRecruitingPlayers)
             DrawRecruitingPlayersDebugRows();
+    }
+
+    private static void DrawRecentChatPlayerDebugRow(string playerName, long expireTime, long now)
+    {
+        TryFindPlayerByName(playerName, out var player);
+
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted("Recent chat");
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugPlayerName(player, playerName));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(player != null ? GetPlayerTrackingID(player).ToString() : "-");
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugRemainTimeText(expireTime, now));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugDistanceText(player));
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(GetDebugTargetIDText(player));
     }
 
     private void DrawRecruitingPlayersDebugRows()
@@ -252,6 +301,53 @@ public unsafe class AutoHideGameObjects : ModuleBase
         var orig = UpdateObjectArraysHook.Original(objectManager);
         UpdateAllObjects(objectManager);
         return orig;
+    }
+
+    private void MigrateConfig()
+    {
+        if (config.SplitCompanionOrnamentConfig)
+            return;
+
+        config.DefaultConfig.HideCompanion = config.DefaultConfig.HidePet;
+        config.DefaultConfig.HideOrnament  = config.DefaultConfig.HidePet;
+        config.SplitCompanionOrnamentConfig = true;
+        config.Save(this);
+    }
+
+    private void OnChatMessage(IHandleableChatMessage message)
+    {
+        if (!config.DefaultConfig.KeepRecentChatPlayers || !IsPlayerChatOrEmote(message.LogKind))
+            return;
+
+        var playerNames = GetPlayerNamesFromChatMessage(message);
+        if (playerNames.Count == 0)
+            return;
+
+        var expireTime = Environment.TickCount64 + RECENT_CHAT_PLAYER_KEEP_MS;
+        lock (recentChatPlayersLock)
+        {
+            foreach (var playerName in playerNames)
+                recentChatPlayers[playerName] = expireTime;
+        }
+    }
+
+    private static HashSet<string> GetPlayerNamesFromChatMessage(IHandleableChatMessage message)
+    {
+        var playerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        AddPlayerPayloadNames(playerNames, message.Sender);
+        AddPlayerPayloadNames(playerNames, message.Message);
+
+        // 有些频道/表情文本不一定带 PlayerPayload；兜底从当前对象表里按完整角色名反查。
+        AddMentionedVisiblePlayerNames(playerNames, $"{message.Sender.TextValue}\n{message.Message.TextValue}");
+
+        return playerNames;
+    }
+
+    private static void AddPlayerPayloadNames(HashSet<string> playerNames, SeString text)
+    {
+        foreach (var payload in text.Payloads.OfType<PlayerPayload>())
+            AddRecentChatPlayerName(playerNames, payload.PlayerName);
     }
 
     private void UpdateAllObjects(GameObjectManager* manager)
@@ -351,7 +447,12 @@ public unsafe class AutoHideGameObjects : ModuleBase
     }
 
     private static bool HasActiveFilter(FilterConfig config) =>
-        config.HidePlayer || config.HidePet || config.HideChocobo || config.HideUnimportantENPC;
+        config.HidePlayer ||
+        config.HidePet ||
+        config.HideCompanion ||
+        config.HideOrnament ||
+        config.HideChocobo ||
+        config.HideUnimportantENPC;
 
     private bool ShouldFilter(FilterConfig config, GameObject* gameObject, uint index, bool isProcessed)
     {
@@ -369,10 +470,17 @@ public unsafe class AutoHideGameObjects : ModuleBase
             !ShouldKeepPlayerVisible(config, (BattleChara*)gameObject))
             return true;
 
-        // 宠物
-        if (config.HidePet                             &&
-            IsOddObjectSlot(index)                     &&
-            gameObject->ObjectKind != ObjectKind.Mount &&
+        // 非战斗宠物
+        if (config.HideCompanion                         &&
+            IsOddObjectSlot(index)                       &&
+            gameObject->ObjectKind == ObjectKind.Companion &&
+            gameObject->OwnerId    != LocalPlayerState.EntityID)
+            return true;
+
+        // 时尚配饰
+        if (config.HideOrnament                         &&
+            IsOddObjectSlot(index)                      &&
+            gameObject->ObjectKind == ObjectKind.Ornament &&
             gameObject->OwnerId    != LocalPlayerState.EntityID)
             return true;
 
@@ -445,6 +553,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
                IsTargetOrFocusPlayerKept(config, player)             ||
                IsTargetingMePlayerKept(config, player)               ||
                IsRecruitingPlayer(config, player)                    ||
+               IsRecentChatPlayerKept(config, player)                ||
                IsNearbyPlayerKept(config, player);
     }
 
@@ -510,6 +619,28 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private static bool IsRecruitingPlayer(FilterConfig config, BattleChara* player) =>
         config.KeepRecruitingPlayers && player != null && player->OnlineStatus == RECRUITING_ONLINE_STATUS_ID;
 
+    private bool IsRecentChatPlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepRecentChatPlayers || player == null)
+            return false;
+
+        var playerName = NormalizePlayerName(((GameObject*)player)->NameString);
+        if (string.IsNullOrWhiteSpace(playerName))
+            return false;
+
+        lock (recentChatPlayersLock)
+        {
+            if (!recentChatPlayers.TryGetValue(playerName, out var expireTime))
+                return false;
+
+            if (expireTime > Environment.TickCount64)
+                return true;
+
+            recentChatPlayers.Remove(playerName);
+            return false;
+        }
+    }
+
     private bool IsNearbyPlayerKept(FilterConfig config, BattleChara* player)
     {
         if (!config.KeepNearbyPlayers || player == null)
@@ -557,6 +688,89 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private static ulong GetLocalPlayerGameObjectID() =>
         LocalPlayerState.Object?.GameObjectID ?? 0;
 
+    private static bool IsPlayerChatOrEmote(XivChatType chatType) =>
+        chatType is XivChatType.Say             or
+                    XivChatType.Yell            or
+                    XivChatType.Shout           or
+                    XivChatType.TellIncoming    or
+                    XivChatType.Party           or
+                    XivChatType.CrossParty      or
+                    XivChatType.Alliance        or
+                    XivChatType.FreeCompany     or
+                    XivChatType.PvPTeam         or
+                    XivChatType.NoviceNetwork   or
+                    XivChatType.CrossLinkShell1 or
+                    XivChatType.CrossLinkShell2 or
+                    XivChatType.CrossLinkShell3 or
+                    XivChatType.CrossLinkShell4 or
+                    XivChatType.CrossLinkShell5 or
+                    XivChatType.CrossLinkShell6 or
+                    XivChatType.CrossLinkShell7 or
+                    XivChatType.CrossLinkShell8 or
+                    XivChatType.Ls1             or
+                    XivChatType.Ls2             or
+                    XivChatType.Ls3             or
+                    XivChatType.Ls4             or
+                    XivChatType.Ls5             or
+                    XivChatType.Ls6             or
+                    XivChatType.Ls7             or
+                    XivChatType.Ls8             ||
+        chatType.ToString().Contains("Emote", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizePlayerName(string playerName)
+    {
+        if (string.IsNullOrWhiteSpace(playerName))
+            return string.Empty;
+
+        return string.Join(' ', playerName.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static void AddRecentChatPlayerName(HashSet<string> playerNames, string playerName)
+    {
+        var normalizedName = NormalizePlayerName(playerName);
+        if (!string.IsNullOrWhiteSpace(normalizedName))
+            playerNames.Add(normalizedName);
+    }
+
+    private static void AddMentionedVisiblePlayerNames(HashSet<string> playerNames, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return;
+
+        var manager = GameObjectManager.Instance();
+        if (manager == null)
+            return;
+
+        for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+        {
+            if (index > 200)
+                break;
+
+            var gameObject = manager->Objects.IndexSorted[index].Value;
+            if (!IsPlayerObject(gameObject, (uint)index))
+                continue;
+
+            var playerName = NormalizePlayerName(gameObject->NameString);
+            if (string.IsNullOrWhiteSpace(playerName) ||
+                !text.Contains(playerName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            playerNames.Add(playerName);
+        }
+    }
+
+    private int GetRecentChatPlayerCount()
+    {
+        lock (recentChatPlayersLock)
+            return recentChatPlayers.Count;
+    }
+
+    private KeyValuePair<string, long>[] GetRecentChatPlayerSnapshot()
+    {
+        lock (recentChatPlayersLock)
+            return recentChatPlayers.ToArray();
+    }
+
     private static bool TryFindPlayerByTrackingID(ulong playerID, out BattleChara* player)
     {
         player = null;
@@ -585,10 +799,53 @@ public unsafe class AutoHideGameObjects : ModuleBase
         return false;
     }
 
+    private static bool TryFindPlayerByName(string playerName, out BattleChara* player)
+    {
+        player = null;
+
+        var normalizedName = NormalizePlayerName(playerName);
+        var manager = GameObjectManager.Instance();
+        if (manager == null || string.IsNullOrWhiteSpace(normalizedName))
+            return false;
+
+        for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+        {
+            if (index > 200)
+                break;
+
+            var gameObject = manager->Objects.IndexSorted[index].Value;
+            if (!IsPlayerObject(gameObject, (uint)index))
+                continue;
+
+            var currentPlayer = (BattleChara*)gameObject;
+            var currentPlayerName = NormalizePlayerName(((GameObject*)currentPlayer)->NameString);
+            if (!PlayerNameEquals(normalizedName, currentPlayerName))
+                continue;
+
+            player = currentPlayer;
+            return true;
+        }
+
+        return false;
+    }
+
     private static string GetDebugPlayerName(BattleChara* player) =>
         player == null || string.IsNullOrWhiteSpace(((GameObject*)player)->NameString)
             ? "(not in object table)"
             : ((GameObject*)player)->NameString;
+
+    private static string GetDebugPlayerName(BattleChara* player, string fallbackName) =>
+        player == null || string.IsNullOrWhiteSpace(((GameObject*)player)->NameString)
+            ? $"{fallbackName} (not in object table)"
+            : ((GameObject*)player)->NameString;
+
+    private static bool PlayerNameEquals(string candidateName, string objectName)
+    {
+        if (string.IsNullOrWhiteSpace(candidateName) || string.IsNullOrWhiteSpace(objectName))
+            return false;
+
+        return candidateName.Equals(objectName, StringComparison.OrdinalIgnoreCase);
+    }
 
     private static string GetDebugRemainTimeText(long? expireTime, long now)
     {
@@ -772,6 +1029,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
         nearbyKeptPlayers.Clear();
         targetingMePlayers.Clear();
         recentTargetPlayers.Clear();
+        ClearRecentChatPlayers();
     }
 
     // 尽量把所有本模块隐藏过的对象恢复显示，然后忘记所有运行期状态
@@ -823,6 +1081,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         PruneExpiredPlayerRecords(targetingMePlayers);
         PruneExpiredPlayerRecords(recentTargetPlayers);
+        PruneExpiredRecentChatPlayers();
 
         // 主要是小区域更新不及时；新增的动态保留规则开启时才需要持续刷新。
         if (!NeedsContinuousRefresh() && zoneUpdateCount > 3) return;
@@ -840,7 +1099,8 @@ public unsafe class AutoHideGameObjects : ModuleBase
                (filterConfig.KeepRecruitingPlayers     ||
                 filterConfig.KeepNearbyPlayers         ||
                 filterConfig.KeepTargetAndFocusPlayers ||
-                filterConfig.KeepPlayersTargetingMe);
+                filterConfig.KeepPlayersTargetingMe    ||
+                filterConfig.KeepRecentChatPlayers);
     }
 
     private static void PruneExpiredPlayerRecords(Dictionary<ulong, long> playerRecords)
@@ -853,9 +1113,31 @@ public unsafe class AutoHideGameObjects : ModuleBase
             playerRecords.Remove(playerID);
     }
 
+    private void PruneExpiredRecentChatPlayers()
+    {
+        lock (recentChatPlayersLock)
+        {
+            if (recentChatPlayers.Count == 0)
+                return;
+
+            var now = Environment.TickCount64;
+            foreach (var playerName in recentChatPlayers.Where(x => x.Value <= now).Select(x => x.Key).ToArray())
+                recentChatPlayers.Remove(playerName);
+        }
+    }
+
+    private void ClearRecentChatPlayers()
+    {
+        lock (recentChatPlayersLock)
+            recentChatPlayers.Clear();
+    }
+
     private class Config : ModuleConfig
     {
         public FilterConfig DefaultConfig = new();
+
+        // 兼容旧配置: 拆分非战斗宠物/时尚配饰开关前, 它们跟随 HidePet。
+        public bool SplitCompanionOrnamentConfig;
     }
 
     private class FilterConfig
@@ -865,6 +1147,12 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         // 宠物
         public bool HidePet = true;
+
+        // 非战斗宠物
+        public bool HideCompanion = true;
+
+        // 时尚配饰
+        public bool HideOrnament = true;
 
         // 玩家
         public bool HidePlayer = true;
@@ -882,6 +1170,9 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         // 保留一段时间内以自己为目标的玩家
         public bool KeepPlayersTargetingMe = true;
+
+        // 保留最近发言或发送表情的玩家
+        public bool KeepRecentChatPlayers = true;
 
         // 不重要 NPC
         public bool HideUnimportantENPC = true;

--- a/System/AutoHideGameObjects.cs
+++ b/System/AutoHideGameObjects.cs
@@ -3,7 +3,6 @@ using DailyRoutines.Common.Module.Enums;
 using DailyRoutines.Common.Module.Models;
 using DailyRoutines.Extensions;
 using Dalamud.Hooking;
-using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Enums;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
@@ -16,27 +15,37 @@ namespace DailyRoutines.ModulesPublic;
 
 public unsafe class AutoHideGameObjects : ModuleBase
 {
+    private const float NEARBY_PLAYER_RANGE_HYSTERESIS = 1.5f;
+    private const int   TARGETING_ME_PLAYER_KEEP_MS    = 60_000;
+    private const int   RECENT_TARGET_PLAYER_KEEP_MS   = 30_000;
+    private const byte  RECRUITING_ONLINE_STATUS_ID    = 26;  // 队员招募中
+
     public override ModuleInfo Info { get; } = new()
     {
         Title       = Lang.Get("AutoHideGameObjectsTitle"),
         Description = Lang.Get("AutoHideGameObjectsDescription"),
         Category    = ModuleCategory.System
     };
-    
+
     private static readonly CompSig                          UpdateObjectArraysSig = new("40 57 48 83 EC ?? 48 89 5C 24 ?? 33 DB");
     private delegate        void*                            UpdateObjectArraysDelegate(GameObjectManager* objectManager);
     private                 Hook<UpdateObjectArraysDelegate> UpdateObjectArraysHook;
 
     private Config config = null!;
 
-    private readonly HashSet<nint> processedObjects = [];
+    private readonly Dictionary<nint, HiddenObjectRecord> processedObjects          = [];
+    private readonly Dictionary<ulong, long>              targetingMePlayers        = [];
+    private readonly Dictionary<ulong, long>              recentTargetPlayers       = [];
+    private readonly HashSet<ulong>                       nearbyKeptPlayers         = [];
+    private readonly HashSet<nint>                        objectsHiddenThisScan     = [];
+    private readonly HashSet<ulong>                       nearbyPlayersSeenThisScan = [];
 
     private int zoneUpdateCount;
 
     protected override void Init()
     {
-        TaskHelper   ??= new() { TimeoutMS = 30_000 };
-        config =   Config.Load(this) ?? new();
+        TaskHelper ??= new() { TimeoutMS = 30_000 };
+        config = Config.Load(this) ?? new();
 
         UpdateObjectArraysHook ??= UpdateObjectArraysSig.GetHook<UpdateObjectArraysDelegate>(UpdateObjectArraysDetour);
         UpdateObjectArraysHook.Enable();
@@ -57,27 +66,82 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
     protected override void ConfigUI()
     {
+        var defaultConfig = config.DefaultConfig;
+        var changed = false;
+
+        static bool Checkbox(string labelKey, ref bool value, string helpKey)
+        {
+            var itemChanged = ImGui.Checkbox(Lang.Get(labelKey), ref value);
+            ImGuiOm.TooltipHover(Lang.Get(helpKey));
+            return itemChanged;
+        }
+
         ImGui.TextColored(KnownColor.LightSkyBlue.ToVector4(), Lang.Get("Default"));
 
         using (ImRaii.PushId("Default"))
         using (ImRaii.PushIndent())
         {
-            if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HidePlayer"), ref config.DefaultConfig.HidePlayer))
-                config.Save(this);
-            ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HidePlayerHelp"));
+            changed |= Checkbox("AutoHideGameObjects-HidePlayer",
+                                ref defaultConfig.HidePlayer,
+                                "AutoHideGameObjects-HidePlayerHelp");
 
-            if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideUnimportantENPC"), ref config.DefaultConfig.HideUnimportantENPC))
-                config.Save(this);
-            ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideUnimportantENPCHelp"));
+            if (defaultConfig.HidePlayer)
+            {
+                using (ImRaii.PushIndent())
+                {
+                    changed |= Checkbox("AutoHideGameObjects-KeepRecruitingPlayers",
+                                        ref defaultConfig.KeepRecruitingPlayers,
+                                        "AutoHideGameObjects-KeepRecruitingPlayersHelp");
 
-            if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HidePet"), ref config.DefaultConfig.HidePet))
-                config.Save(this);
-            ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HidePetHelp"));
+                    changed |= Checkbox("AutoHideGameObjects-KeepNearbyPlayers",
+                                        ref defaultConfig.KeepNearbyPlayers,
+                                        "AutoHideGameObjects-KeepNearbyPlayersHelp");
 
-            if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideChocobo"), ref config.DefaultConfig.HideChocobo))
-                config.Save(this);
-            ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideChocoboHelp"));
+                    if (defaultConfig.KeepNearbyPlayers)
+                    {
+                        using var nearbyIndent = ImRaii.PushIndent();
+
+                        ImGui.SetNextItemWidth(160f);
+                        if (ImGui.SliderFloat
+                            (
+                                $"{Lang.Get("AutoHideGameObjects-KeepNearbyPlayersRange")}###AutoHideGameObjectsKeepNearbyPlayersRange",
+                                ref defaultConfig.KeepNearbyPlayersRange,
+                                1f,
+                                50f,
+                                "%.1f"
+                            ))
+                            defaultConfig.KeepNearbyPlayersRange =
+                                Math.Clamp(defaultConfig.KeepNearbyPlayersRange, 1f, 50f);
+
+                        if (ImGui.IsItemDeactivatedAfterEdit())
+                            changed = true;
+                    }
+
+                    changed |= Checkbox("AutoHideGameObjects-KeepTargetAndFocusPlayers",
+                                        ref defaultConfig.KeepTargetAndFocusPlayers,
+                                        "AutoHideGameObjects-KeepTargetAndFocusPlayersHelp");
+
+                    changed |= Checkbox("AutoHideGameObjects-KeepPlayersTargetingMe",
+                                        ref defaultConfig.KeepPlayersTargetingMe,
+                                        "AutoHideGameObjects-KeepPlayersTargetingMeHelp");
+                }
+            }
+
+            changed |= Checkbox("AutoHideGameObjects-HideUnimportantENPC",
+                                ref defaultConfig.HideUnimportantENPC,
+                                "AutoHideGameObjects-HideUnimportantENPCHelp");
+
+            changed |= Checkbox("AutoHideGameObjects-HidePet",
+                                ref defaultConfig.HidePet,
+                                "AutoHideGameObjects-HidePetHelp");
+
+            changed |= Checkbox("AutoHideGameObjects-HideChocobo",
+                                ref defaultConfig.HideChocobo,
+                                "AutoHideGameObjects-HideChocoboHelp");
         }
+
+        if (changed)
+            SaveConfigAndRefresh();
     }
 
     private void* UpdateObjectArraysDetour(GameObjectManager* objectManager)
@@ -90,28 +154,29 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private void UpdateAllObjects(GameObjectManager* manager)
     {
         if (manager == null) return;
-        if (!GameState.IsLoggedIn) return;
 
-        if (GameState.TerritoryIntendedUse != TerritoryIntendedUse.OccultCrescent)
+        if (!GameState.IsLoggedIn)
         {
-            if (GameState.ContentFinderCondition != 0 ||
-                GameState.IsInPVPArea                 ||
-                GameState.TerritoryIntendedUse == TerritoryIntendedUse.IslandSanctuary)
-                return;
-        }
-        else
-        {
-            // 在两歧塔里
-            if ((LocalPlayerState.Object?.Position.Y ?? -100) < 0)
-                return;
-        }
-
-        var playerCount   = 0;
-        var targetAddress = TargetManager.Target?.Address ?? nint.Zero;
-
-        if (GameState.TerritoryIntendedUse                == TerritoryIntendedUse.OccultCrescent &&
-            (LocalPlayerState.Object?.Position.Y ?? -100) < 0)
+            ClearProcessedObjects();
             return;
+        }
+
+        if (!IsActiveTerritory())
+        {
+            ResetAllObjects();
+            return;
+        }
+
+        var isOccultCrescent = GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent;
+        if (!isOccultCrescent && !HasActiveFilter(config.DefaultConfig))
+        {
+            ResetAllObjects();
+            return;
+        }
+
+        var occultCrescentPlayerCount = 0;
+        var targetAddress             = TargetManager.Target?.Address ?? nint.Zero;
+        var nearbyPlayersSeen         = BeginObjectScan(isOccultCrescent);
 
         for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
         {
@@ -124,83 +189,106 @@ public unsafe class AutoHideGameObjects : ModuleBase
                 continue;
             }
 
-            var entry = manager->Objects.IndexSorted[index];
+            var gameObject = manager->Objects.IndexSorted[index].Value;
 
-            if (GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent)
+            TrackNearbyPlayerSeen(gameObject, (uint)index, nearbyPlayersSeen);
+
+            if (!ShouldHideObject(gameObject, (uint)index, isOccultCrescent, targetAddress, ref occultCrescentPlayerCount))
             {
-                if (!ShouldFilterOccultCrescent(entry.Value, targetAddress, ref playerCount, (uint)index))
-                    continue;
-            }
-            else
-            {
-                if (!ShouldFilter(config.DefaultConfig, entry.Value, (uint)index))
-                    continue;
+                RestoreObjectIfProcessed(gameObject, isOccultCrescent);
+                continue;
             }
 
-            entry.Value->RenderFlags |= (VisibilityFlags)256;
-            processedObjects.Add((nint)entry.Value);
+            HideObject(gameObject);
         }
+
+        FinishObjectScan(manager, nearbyPlayersSeen, isOccultCrescent);
     }
 
-    private static bool ShouldFilter(FilterConfig config, GameObject* gameObject, uint index)
+    private HashSet<ulong>? BeginObjectScan(bool isOccultCrescent)
+    {
+        objectsHiddenThisScan.Clear();
+
+        if (isOccultCrescent || !config.DefaultConfig.HidePlayer || !config.DefaultConfig.KeepNearbyPlayers)
+            return null;
+
+        nearbyPlayersSeenThisScan.Clear();
+        return nearbyPlayersSeenThisScan;
+    }
+
+    private bool ShouldHideObject(GameObject* gameObject, uint index, bool isOccultCrescent, nint targetAddress, ref int occultCrescentPlayerCount)
+    {
+        if (isOccultCrescent)
+            return ShouldFilterOccultCrescent(gameObject, targetAddress, ref occultCrescentPlayerCount, index);
+
+        var wasHiddenByThisModule = IsProcessedObject(gameObject);
+        return ShouldFilter(config.DefaultConfig, gameObject, index, wasHiddenByThisModule);
+    }
+
+    private void FinishObjectScan(GameObjectManager* manager, HashSet<ulong>? nearbyPlayersSeen, bool isOccultCrescent)
+    {
+        if (isOccultCrescent)
+            return;
+
+        RestoreStaleProcessedObjects(manager, objectsHiddenThisScan);
+        RemoveStaleNearbyKeptPlayers(nearbyPlayersSeen);
+    }
+
+    private static bool IsActiveTerritory()
+    {
+        if (GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent)
+        {
+            // 在两歧塔里
+            return (LocalPlayerState.Object?.Position.Y ?? -100) >= 0;
+        }
+
+        return GameState.ContentFinderCondition == 0 &&
+               !GameState.IsInPVPArea                &&
+               GameState.TerritoryIntendedUse   != TerritoryIntendedUse.IslandSanctuary;
+    }
+
+    private static bool HasActiveFilter(FilterConfig config) =>
+        config.HidePlayer || config.HidePet || config.HideChocobo || config.HideUnimportantENPC;
+
+    private bool ShouldFilter(FilterConfig config, GameObject* gameObject, uint index, bool isProcessed)
     {
         if (gameObject == null) return false;
 
         if (gameObject->EntityId == LocalPlayerState.EntityID) return false;
 
-        if (((RenderFlag)gameObject->RenderFlags).IsSet(RenderFlag.Invisible)) return false;
+        if (!isProcessed && ((RenderFlag)gameObject->RenderFlags).IsSet(RenderFlag.Invisible)) return false;
 
         if (gameObject->NamePlateIconId != 0) return false;
 
         // 玩家
-        if (config.HidePlayer             &&
-            index                  <= 200 &&
-            index % 2              == 0   &&
-            gameObject->ObjectKind == ObjectKind.Pc)
-        {
-            var player = (BattleChara*)gameObject;
-
-            if (player->IsFriend)
-                return false;
-
-            if (LocalPlayerState.IsInParty &&
-                (player->IsPartyMember || player->IsAllianceMember))
-                return false;
-
+        if (config.HidePlayer                 &&
+            IsPlayerObject(gameObject, index) &&
+            !ShouldKeepPlayerVisible(config, (BattleChara*)gameObject))
             return true;
-        }
 
         // 宠物
         if (config.HidePet                             &&
-            index                  <= 200              &&
-            index % 2              == 1                &&
+            IsOddObjectSlot(index)                     &&
             gameObject->ObjectKind != ObjectKind.Mount &&
             gameObject->OwnerId    != LocalPlayerState.EntityID)
             return true;
-        
+
         // 战斗召唤物
         if (config.HidePet                                                &&
-            index                                 <= 200                  &&
-            index % 2                             == 0                    &&
-            gameObject->ObjectKind                == ObjectKind.BattleNpc &&
+            IsBattleNPCInEvenObjectSlot(gameObject, index)                &&
             (BattleNpcSubKind)gameObject->SubKind == BattleNpcSubKind.Pet &&
             gameObject->OwnerId                   != LocalPlayerState.EntityID)
             return true;
 
         // 陆行鸟
-        if (config.HideChocobo                                                &&
-            index                                 <= 200                      &&
-            index % 2                             == 0                        &&
-            gameObject->ObjectKind                == ObjectKind.BattleNpc     &&
-            (BattleNpcSubKind)gameObject->SubKind == BattleNpcSubKind.Buddy   &&
+        if (config.HideChocobo                                              &&
+            IsBattleNPCInEvenObjectSlot(gameObject, index)                  &&
+            (BattleNpcSubKind)gameObject->SubKind == BattleNpcSubKind.Buddy &&
             gameObject->OwnerId                   != LocalPlayerState.EntityID)
             return true;
 
         // 不重要 NPC
-        if (config.HideUnimportantENPC                                              &&
-            index is >= 489 and <= 629                                              &&
-            !gameObject->TargetableStatus.IsSet(ObjectTargetableFlags.IsTargetable) &&
-            gameObject->EventHandler == null)
+        if (config.HideUnimportantENPC && IsUnimportantEventNPC(gameObject, index))
             return true;
 
         return false;
@@ -214,10 +302,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         if (gameObject->NamePlateIconId != 0) return false;
 
-        // 玩家
-        if (index                  <= 200 &&
-            index % 2              == 0   &&
-            gameObject->ObjectKind == ObjectKind.Pc)
+        if (IsPlayerObject(gameObject, index))
         {
             var player = (BattleChara*)gameObject;
 
@@ -240,61 +325,369 @@ public unsafe class AutoHideGameObjects : ModuleBase
             return playerCount >= 10;
         }
 
-        // 不重要 NPC
-        if (index is >= 489 and <= 629                                              &&
-            !gameObject->TargetableStatus.IsSet(ObjectTargetableFlags.IsTargetable) &&
-            gameObject->EventHandler == null)
+        if (IsUnimportantEventNPC(gameObject, index))
             return true;
 
-        // 其他玩家的召唤物
-        if (gameObject->ObjectKind == ObjectKind.BattleNpc      &&
-            index                  <= 200                       &&
-            index % 2              == 0                         &&
-            gameObject->ObjectKind == ObjectKind.BattleNpc      &&
-            gameObject->OwnerId    != LocalPlayerState.EntityID &&
-            gameObject->OwnerId    != 0                         &&
-            gameObject->OwnerId    != 0xE0000000)
+        if (IsBattleNPCInEvenObjectSlot(gameObject, index) && IsOwnedByOtherPlayer(gameObject))
             return true;
 
         return false;
     }
 
+    private bool ShouldKeepPlayerVisible(FilterConfig config, BattleChara* player)
+    {
+        return player->IsFriend                                      ||
+               (LocalPlayerState.IsInParty &&
+                (player->IsPartyMember || player->IsAllianceMember)) ||
+               IsTargetOrFocusPlayerKept(config, player)             ||
+               IsTargetingMePlayerKept(config, player)               ||
+               IsRecruitingPlayer(config, player)                    ||
+               IsNearbyPlayerKept(config, player);
+    }
+
+    private bool IsTargetOrFocusPlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepTargetAndFocusPlayers || player == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        var address = (nint)player;
+        if (address == (TargetManager.Target?.Address ?? nint.Zero) ||
+            address == (TargetManager.FocusTarget?.Address ?? nint.Zero))
+        {
+            // 当前目标/焦点立即保留，并在取消目标后继续保留一小段时间。
+            recentTargetPlayers[playerID] = Environment.TickCount64 + RECENT_TARGET_PLAYER_KEEP_MS;
+            return true;
+        }
+
+        if (!recentTargetPlayers.TryGetValue(playerID, out var expireTime))
+            return false;
+
+        if (expireTime > Environment.TickCount64)
+            return true;
+
+        recentTargetPlayers.Remove(playerID);
+        return false;
+    }
+
+    private bool IsTargetingMePlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepPlayersTargetingMe || player == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        var localPlayerID = GetLocalPlayerGameObjectID();
+        if (localPlayerID == 0)
+            return false;
+
+        var now = Environment.TickCount64;
+        if ((ulong)player->GetTargetId() == localPlayerID)
+        {
+            // 发现对方当前以我为目标后，记录一个过期时间；过期前都保持可见。
+            targetingMePlayers[playerID] = now + TARGETING_ME_PLAYER_KEEP_MS;
+            return true;
+        }
+
+        if (!targetingMePlayers.TryGetValue(playerID, out var expireTime))
+            return false;
+
+        if (expireTime > now)
+            return true;
+
+        targetingMePlayers.Remove(playerID);
+        return false;
+    }
+
+    private static bool IsRecruitingPlayer(FilterConfig config, BattleChara* player) =>
+        config.KeepRecruitingPlayers && player != null && player->OnlineStatus == RECRUITING_ONLINE_STATUS_ID;
+
+    private bool IsNearbyPlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepNearbyPlayers || player == null)
+            return false;
+
+        var localPlayer = LocalPlayerState.Object;
+        if (localPlayer == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        var range    = Math.Clamp(config.KeepNearbyPlayersRange, 1f, 50f);
+        var distance = LocalPlayerState.DistanceTo3D(player->Position);
+
+        if (nearbyKeptPlayers.Contains(playerID))
+        {
+            // 已经因“身边范围”保留的玩家，用稍大的退出半径防止边界来回闪烁。
+            var exitRange = range + NEARBY_PLAYER_RANGE_HYSTERESIS;
+            if (distance <= exitRange)
+                return true;
+
+            nearbyKeptPlayers.Remove(playerID);
+            return false;
+        }
+
+        if (distance > range)
+            return false;
+
+        nearbyKeptPlayers.Add(playerID);
+        return true;
+    }
+
+    private static ulong GetPlayerTrackingID(BattleChara* player)
+    {
+        if (player == null)
+            return 0;
+
+        return player->ContentId != 0
+                   ? player->ContentId
+                   : (ulong)((GameObject*)player)->GetGameObjectId();
+    }
+
+    private static ulong GetLocalPlayerGameObjectID() =>
+        LocalPlayerState.Object?.GameObjectID ?? 0;
+
+    private static bool IsPlayerObject(GameObject* gameObject, uint index) =>
+        gameObject             != null &&
+        IsEvenObjectSlot(index)        &&
+        gameObject->ObjectKind == ObjectKind.Pc;
+
+    private static bool IsBattleNPCInEvenObjectSlot(GameObject* gameObject, uint index) =>
+        gameObject             != null &&
+        IsEvenObjectSlot(index)        &&
+        gameObject->ObjectKind == ObjectKind.BattleNpc;
+
+    private static bool IsEvenObjectSlot(uint index) =>
+        index <= 200 && index % 2 == 0;
+
+    private static bool IsOddObjectSlot(uint index) =>
+        index <= 200 && index % 2 == 1;
+
+    private static bool IsUnimportantEventNPC(GameObject* gameObject, uint index) =>
+        gameObject != null                                                      &&
+        index is >= 489 and <= 629                                              &&
+        !gameObject->TargetableStatus.IsSet(ObjectTargetableFlags.IsTargetable) &&
+        gameObject->EventHandler == null;
+
+    private static bool IsOwnedByOtherPlayer(GameObject* gameObject) =>
+        gameObject          != null                      &&
+        gameObject->OwnerId != LocalPlayerState.EntityID &&
+        gameObject->OwnerId != 0                         &&
+        gameObject->OwnerId != 0xE0000000;
+
+    private static void TrackNearbyPlayerSeen(GameObject* gameObject, uint index, HashSet<ulong>? nearbyPlayersSeen)
+    {
+        if (nearbyPlayersSeen == null || !IsPlayerObject(gameObject, index))
+            return;
+
+        var playerID = GetPlayerTrackingID((BattleChara*)gameObject);
+        if (playerID != 0)
+            nearbyPlayersSeen.Add(playerID);
+    }
+
+    private void SaveConfigAndRefresh()
+    {
+        config.Save(this);
+        ResetAllObjects();
+        UpdateAllObjects(GameObjectManager.Instance());
+    }
+
+    private void HideObject(GameObject* gameObject)
+    {
+        if (gameObject == null) return;
+
+        var address = (nint)gameObject;
+        if (address == nint.Zero)
+            return;
+
+        gameObject->RenderFlags |= (VisibilityFlags)256;
+        processedObjects[address] = HiddenObjectRecord.From(gameObject);
+        objectsHiddenThisScan.Add(address);
+    }
+
+    private bool IsProcessedObject(GameObject* gameObject)
+    {
+        if (gameObject == null) return false;
+
+        var address = (nint)gameObject;
+        if (!processedObjects.TryGetValue(address, out var record))
+            return false;
+
+        if (record.IsSameObject(gameObject))
+            return true;
+
+        processedObjects.Remove(address);
+        return false;
+    }
+
+    private void RestoreObjectIfProcessed(GameObject* gameObject, bool isOccultCrescent = false)
+    {
+        if (isOccultCrescent)
+            return;
+
+        if (gameObject == null) return;
+
+        var address = (nint)gameObject;
+        if (!processedObjects.TryGetValue(address, out var record))
+            return;
+
+        processedObjects.Remove(address);
+
+        if (!record.IsSameObject(gameObject))
+            return;
+
+        gameObject->RenderFlags &= ~(VisibilityFlags)256;
+    }
+
+    private void RestoreStaleProcessedObjects(GameObjectManager* manager, HashSet<nint> objectsHiddenThisScan)
+    {
+        if (processedObjects.Count == 0) return;
+
+        foreach (var address in processedObjects.Keys.ToArray())
+        {
+            if (objectsHiddenThisScan.Contains(address))
+                continue;
+
+            // 本轮没再命中隐藏条件的旧对象，如果仍能在对象表里找到同一实例，就恢复可见。
+            if (TryFindObject(manager, address, processedObjects[address], out var gameObject))
+                gameObject->RenderFlags &= ~(VisibilityFlags)256;
+
+            processedObjects.Remove(address);
+        }
+    }
+
+    private static bool TryFindObject(GameObjectManager* manager, nint address, HiddenObjectRecord record, out GameObject* gameObject)
+    {
+        gameObject = null;
+        if (manager == null || address == nint.Zero)
+            return false;
+
+        foreach (ref var entry in manager->Objects.IndexSorted)
+        {
+            if ((nint)entry.Value != address || !record.IsSameObject(entry.Value))
+                continue;
+
+            gameObject = entry.Value;
+            return true;
+        }
+
+        return false;
+    }
+
+    private void RemoveStaleNearbyKeptPlayers(HashSet<ulong>? nearbyPlayersSeen)
+    {
+        if (nearbyKeptPlayers.Count == 0)
+            return;
+
+        if (nearbyPlayersSeen == null)
+        {
+            nearbyKeptPlayers.Clear();
+            return;
+        }
+
+        foreach (var playerID in nearbyKeptPlayers.ToArray())
+        {
+            // 玩家不在本轮对象表里时，移除“曾经在身边”的缓存，避免下次复用旧状态。
+            if (!nearbyPlayersSeen.Contains(playerID))
+                nearbyKeptPlayers.Remove(playerID);
+        }
+    }
+
+    // 忘记所有运行期状态
+    private void ClearProcessedObjects()
+    {
+        processedObjects.Clear();
+        nearbyKeptPlayers.Clear();
+        targetingMePlayers.Clear();
+        recentTargetPlayers.Clear();
+    }
+
+    // 尽量把所有本模块隐藏过的对象恢复显示，然后忘记所有运行期状态
     private void ResetAllObjects()
     {
-        if (!DService.Instance().ClientState.IsLoggedIn || processedObjects.Count == 0) return;
+        if (processedObjects.Count == 0)
+        {
+            ClearProcessedObjects();
+            return;
+        }
+
+        if (!DService.Instance().ClientState.IsLoggedIn)
+        {
+            ClearProcessedObjects();
+            return;
+        }
 
         var manager = GameObjectManager.Instance();
-        if (manager == null) return;
+        if (manager == null)
+        {
+            ClearProcessedObjects();
+            return;
+        }
 
-        foreach (ref var entry in GameObjectManager.Instance()->Objects.IndexSorted)
+        foreach (ref var entry in manager->Objects.IndexSorted)
         {
             if (entry.Value       == null                                            ||
                 (nint)entry.Value == (LocalPlayerState.Object?.Address ?? nint.Zero) ||
-                !processedObjects.Contains((nint)entry.Value))
+                !processedObjects.TryGetValue((nint)entry.Value, out var record)     ||
+                !record.IsSameObject(entry.Value))
                 continue;
 
             entry.Value->RenderFlags &= ~(VisibilityFlags)256;
         }
 
-        processedObjects.Clear();
+        ClearProcessedObjects();
         zoneUpdateCount = 0;
     }
 
     private void OnZoneChanged(uint u)
     {
         zoneUpdateCount = 0;
-        processedObjects.Clear();
+        ResetAllObjects();
     }
 
     private void OnUpdate(IFramework _)
     {
-        // 主要是小区域更新不及时
-        if (zoneUpdateCount > 3 || DService.Instance().Condition.IsBetweenAreas) return;
+        if (DService.Instance().Condition.IsBetweenAreas) return;
+
+        PruneExpiredPlayerRecords(targetingMePlayers);
+        PruneExpiredPlayerRecords(recentTargetPlayers);
+
+        // 主要是小区域更新不及时；新增的动态保留规则开启时才需要持续刷新。
+        if (!NeedsContinuousRefresh() && zoneUpdateCount > 3) return;
 
         zoneUpdateCount++;
         UpdateAllObjects(GameObjectManager.Instance());
     }
-    
+
+    private bool NeedsContinuousRefresh()
+    {
+        var filterConfig = config.DefaultConfig;
+
+        // 这些规则依赖会随时间变化的数据，所以不能只靠切区后的少量补扫。
+        return filterConfig.HidePlayer &&
+               (filterConfig.KeepRecruitingPlayers     ||
+                filterConfig.KeepNearbyPlayers         ||
+                filterConfig.KeepTargetAndFocusPlayers ||
+                filterConfig.KeepPlayersTargetingMe);
+    }
+
+    private static void PruneExpiredPlayerRecords(Dictionary<ulong, long> playerRecords)
+    {
+        if (playerRecords.Count == 0)
+            return;
+
+        var now = Environment.TickCount64;
+        foreach (var playerID in playerRecords.Where(x => x.Value <= now).Select(x => x.Key).ToArray())
+            playerRecords.Remove(playerID);
+    }
+
     private class Config : ModuleConfig
     {
         public FilterConfig DefaultConfig = new();
@@ -311,8 +704,33 @@ public unsafe class AutoHideGameObjects : ModuleBase
         // 玩家
         public bool HidePlayer = true;
 
+        // 保留正在队员招募中的玩家
+        public bool KeepRecruitingPlayers = true;
+
+        // 保留一定距离内的玩家
+        public bool KeepNearbyPlayers;
+
+        public float KeepNearbyPlayersRange = 5f;
+
+        // 保留自己的目标和焦点目标
+        public bool KeepTargetAndFocusPlayers = true;
+
+        // 保留一段时间内以自己为目标的玩家
+        public bool KeepPlayersTargetingMe = true;
+
         // 不重要 NPC
         public bool HideUnimportantENPC = true;
+    }
+
+    private readonly record struct HiddenObjectRecord(ulong GameObjectID, uint EntityID)
+    {
+        public static HiddenObjectRecord From(GameObject* gameObject) =>
+            new((ulong)gameObject->GetGameObjectId(), gameObject->EntityId);
+
+        public bool IsSameObject(GameObject* gameObject) =>
+            gameObject                           != null         &&
+            (ulong)gameObject->GetGameObjectId() == GameObjectID &&
+            gameObject->EntityId                 == EntityID;
     }
 
     private enum RenderFlag

--- a/System/AutoHideGameObjects.cs
+++ b/System/AutoHideGameObjects.cs
@@ -7,15 +7,28 @@ using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Enums;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using OmenTools.Interop.Game.Lumina;
 using OmenTools.Interop.Game.Models;
 using OmenTools.OmenService;
+using System.Numerics;
 using BattleNpcSubKind = Dalamud.Game.ClientState.Objects.Enums.BattleNpcSubKind;
 using ObjectKind = FFXIVClientStructs.FFXIV.Client.Game.Object.ObjectKind;
+using Race = Lumina.Excel.Sheets.Race;
 
 namespace DailyRoutines.ModulesPublic;
 
 public unsafe class AutoHideGameObjects : ModuleBase
 {
+    private const byte MIN_RACE = 1;
+    private const byte MAX_RACE = 8;
+    private const byte MALE_SEX = 0;
+    private const byte FEMALE_SEX = 1;
+    private const float NEARBY_PLAYER_RANGE_HYSTERESIS = 1.5f;
+    private const int TARGETING_ME_PLAYER_KEEP_MS = 60_000;
+    private const int RECENT_TARGET_PLAYER_KEEP_MS = 30_000;
+    private const int OCCULT_VISIBLE_PLAYER_LIMIT = 10;
+    private const byte RECRUITING_ONLINE_STATUS_ID = 26; // OnlineStatus RowId: 队员招募中
+
     public override ModuleInfo Info { get; } = new()
     {
         Title       = Lang.Get("AutoHideGameObjectsTitle"),
@@ -29,9 +42,13 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
     private Config config = null!;
 
-    private readonly HashSet<nint> processedObjects = [];
-
-    private int zoneUpdateCount;
+    private readonly Dictionary<nint, HiddenObjectRecord> processedObjects = [];
+    private readonly Dictionary<ulong, long> targetingMePlayers = [];
+    private readonly Dictionary<ulong, long> recentTargetPlayers = [];
+    private readonly HashSet<ulong> nearbyKeptPlayers = [];
+    private readonly HashSet<nint> seenProcessedObjects = [];
+    private readonly HashSet<ulong> seenNearbyPlayers = [];
+    private bool isUpdatingObjects;
 
     protected override void Init()
     {
@@ -63,21 +80,162 @@ public unsafe class AutoHideGameObjects : ModuleBase
         using (ImRaii.PushIndent())
         {
             if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HidePlayer"), ref config.DefaultConfig.HidePlayer))
-                config.Save(this);
+                SaveConfigAndRefresh();
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HidePlayerHelp"));
 
+            if (config.DefaultConfig.HidePlayer)
+            {
+                DrawRaceFilterUI(config.DefaultConfig);
+
+                using (ImRaii.PushIndent())
+                {
+                    if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-KeepRecruitingPlayers"),
+                                       ref config.DefaultConfig.KeepRecruitingPlayers))
+                        SaveConfigAndRefresh();
+                    ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-KeepRecruitingPlayersHelp"));
+
+                    if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-KeepNearbyPlayers"),
+                                       ref config.DefaultConfig.KeepNearbyPlayers))
+                        SaveConfigAndRefresh();
+                    ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-KeepNearbyPlayersHelp"));
+
+                    if (config.DefaultConfig.KeepNearbyPlayers)
+                    {
+                        using var nearbyIndent = ImRaii.PushIndent();
+
+                        ImGui.SetNextItemWidth(160f);
+                        if (ImGui.SliderFloat
+                            (
+                                $"{Lang.Get("AutoHideGameObjects-KeepNearbyPlayersRange")}###AutoHideGameObjectsKeepNearbyPlayersRange",
+                                ref config.DefaultConfig.KeepNearbyPlayersRange,
+                                1f,
+                                50f,
+                                "%.1f"
+                            ))
+                            config.DefaultConfig.KeepNearbyPlayersRange =
+                                Math.Clamp(config.DefaultConfig.KeepNearbyPlayersRange, 1f, 50f);
+
+                        if (ImGui.IsItemDeactivatedAfterEdit())
+                            SaveConfigAndRefresh();
+                    }
+
+                    if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-KeepTargetAndFocusPlayers"),
+                                       ref config.DefaultConfig.KeepTargetAndFocusPlayers))
+                        SaveConfigAndRefresh();
+                    ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-KeepTargetAndFocusPlayersHelp"));
+
+                    if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-KeepPlayersTargetingMe"),
+                                       ref config.DefaultConfig.KeepPlayersTargetingMe))
+                        SaveConfigAndRefresh();
+                    ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-KeepPlayersTargetingMeHelp"));
+                }
+            }
+
             if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideUnimportantENPC"), ref config.DefaultConfig.HideUnimportantENPC))
-                config.Save(this);
+                SaveConfigAndRefresh();
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideUnimportantENPCHelp"));
 
             if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HidePet"), ref config.DefaultConfig.HidePet))
-                config.Save(this);
+                SaveConfigAndRefresh();
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HidePetHelp"));
 
             if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideChocobo"), ref config.DefaultConfig.HideChocobo))
-                config.Save(this);
+                SaveConfigAndRefresh();
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideChocoboHelp"));
         }
+    }
+
+    private void DrawRaceFilterUI(FilterConfig filterConfig)
+    {
+        using var indent = ImRaii.PushIndent();
+
+        ImGui.TextUnformatted(Lang.Get("AutoHideGameObjects-RaceFilter"));
+
+        using (var combo = ImRaii.Combo("###AutoHideGameObjectsRaceFilterMode", GetRaceFilterModeName(filterConfig.RaceFilterMode)))
+        {
+            if (combo)
+            {
+                foreach (var mode in Enum.GetValues<RaceFilterMode>())
+                {
+                    if (!ImGui.Selectable(GetRaceFilterModeName(mode), filterConfig.RaceFilterMode == mode))
+                        continue;
+
+                    filterConfig.RaceFilterMode = mode;
+                    SaveConfigAndRefresh();
+                }
+            }
+        }
+
+        if (filterConfig.RaceFilterMode == RaceFilterMode.Disabled)
+            return;
+
+        if (filterConfig.RaceFilterMode == RaceFilterMode.HideNotSelected &&
+            filterConfig.RaceSexFilter.Count == 0)
+            ImGui.TextColored(KnownColor.Orange.ToVector4(), Lang.Get("AutoHideGameObjects-RaceFilter-EmptyHideNotSelectedWarning"));
+
+        using (ImRaii.PushId("RaceSexFilter"))
+        {
+            if (ImGui.SmallButton(Lang.Get("AutoHideGameObjects-RaceFilter-SelectAll")))
+            {
+                SetAllRaceSexFilters(filterConfig, true);
+                SaveConfigAndRefresh();
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.SmallButton(Lang.Get("AutoHideGameObjects-RaceFilter-Clear")))
+            {
+                filterConfig.RaceSexFilter.Clear();
+                SaveConfigAndRefresh();
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.SmallButton(Lang.Get("AutoHideGameObjects-RaceFilter-Invert")))
+            {
+                InvertRaceSexFilters(filterConfig);
+                SaveConfigAndRefresh();
+            }
+
+            using var table = ImRaii.Table
+            (
+                "AutoHideGameObjectsRaceSexFilterTable",
+                3,
+                ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.RowBg | ImGuiTableFlags.BordersInnerV
+            );
+
+            if (!table)
+                return;
+
+            ImGui.TableSetupColumn(Lang.Get("AutoHideGameObjects-RaceFilter-Race"), ImGuiTableColumnFlags.WidthFixed, 96f);
+            ImGui.TableSetupColumn(GetSexName(MALE_SEX), ImGuiTableColumnFlags.WidthFixed, 48f);
+            ImGui.TableSetupColumn(GetSexName(FEMALE_SEX), ImGuiTableColumnFlags.WidthFixed, 48f);
+            ImGui.TableHeadersRow();
+
+            for (var race = MIN_RACE; race <= MAX_RACE; race++)
+            {
+                var raceID = (byte)race;
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(GetRaceName(raceID));
+
+                DrawRaceSexFilterCell(filterConfig, raceID, MALE_SEX);
+                DrawRaceSexFilterCell(filterConfig, raceID, FEMALE_SEX);
+            }
+        }
+    }
+
+    private void DrawRaceSexFilterCell(FilterConfig filterConfig, byte race, byte sex)
+    {
+        ImGui.TableNextColumn();
+
+        var selected = filterConfig.RaceSexFilter.Contains(PackRaceSex(race, sex));
+        if (!ImGui.Checkbox($"###AutoHideGameObjectsRaceSexFilter{race}_{sex}", ref selected))
+            return;
+
+        SetRaceSexFilter(filterConfig, race, sex, selected);
+        SaveConfigAndRefresh();
     }
 
     private void* UpdateObjectArraysDetour(GameObjectManager* objectManager)
@@ -90,65 +248,110 @@ public unsafe class AutoHideGameObjects : ModuleBase
     private void UpdateAllObjects(GameObjectManager* manager)
     {
         if (manager == null) return;
-        if (!GameState.IsLoggedIn) return;
+        if (isUpdatingObjects) return;
 
-        if (GameState.TerritoryIntendedUse != TerritoryIntendedUse.OccultCrescent)
+        isUpdatingObjects = true;
+        try
         {
-            if (GameState.ContentFinderCondition != 0 ||
-                GameState.IsInPVPArea                 ||
-                GameState.TerritoryIntendedUse == TerritoryIntendedUse.IslandSanctuary)
+            if (!GameState.IsLoggedIn)
+            {
+                ClearProcessedObjects();
                 return;
-        }
-        else
-        {
-            // 在两歧塔里
-            if ((LocalPlayerState.Object?.Position.Y ?? -100) < 0)
+            }
+
+            if (!IsActiveTerritory())
+            {
+                ResetAllObjects();
                 return;
+            }
+
+            if (!HasActiveFilter(config.DefaultConfig))
+            {
+                ResetAllObjects();
+                return;
+            }
+
+            var playerCount = 0;
+            seenProcessedObjects.Clear();
+            HashSet<ulong>? currentSeenNearbyPlayers = null;
+            if (config.DefaultConfig.HidePlayer && config.DefaultConfig.KeepNearbyPlayers)
+            {
+                seenNearbyPlayers.Clear();
+                currentSeenNearbyPlayers = seenNearbyPlayers;
+            }
+
+            for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+            {
+                if (index > 629)
+                    break;
+
+                if (index is > 200 and < 489)
+                {
+                    index = 488;
+                    continue;
+                }
+
+                var entry       = manager->Objects.IndexSorted[index];
+                var address     = (nint)entry.Value;
+                var isProcessed = IsProcessedObject(entry.Value);
+
+                TrackNearbyPlayer(entry.Value, (uint)index, currentSeenNearbyPlayers);
+
+                if (GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent)
+                {
+                    if (!ShouldFilterOccultCrescent(entry.Value, ref playerCount, (uint)index, isProcessed))
+                    {
+                        RestoreObjectIfProcessed(entry.Value);
+                        continue;
+                    }
+                }
+                else
+                {
+                    if (!ShouldFilter(config.DefaultConfig, entry.Value, (uint)index, isProcessed))
+                    {
+                        RestoreObjectIfProcessed(entry.Value);
+                        continue;
+                    }
+                }
+
+                HideObject(entry.Value);
+
+                if (address != nint.Zero)
+                    seenProcessedObjects.Add(address);
+            }
+
+            RestoreStaleProcessedObjects(manager, seenProcessedObjects);
+            RemoveStaleNearbyKeptPlayers(currentSeenNearbyPlayers);
         }
-
-        var playerCount   = 0;
-        var targetAddress = TargetManager.Target?.Address ?? nint.Zero;
-
-        if (GameState.TerritoryIntendedUse                == TerritoryIntendedUse.OccultCrescent &&
-            (LocalPlayerState.Object?.Position.Y ?? -100) < 0)
-            return;
-
-        for (var index = 0; index < manager->Objects.IndexSorted.Length; index++)
+        finally
         {
-            if (index > 629)
-                break;
-
-            if (index is > 200 and < 489)
-            {
-                index = 488;
-                continue;
-            }
-
-            var entry = manager->Objects.IndexSorted[index];
-
-            if (GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent)
-            {
-                if (!ShouldFilterOccultCrescent(entry.Value, targetAddress, ref playerCount, (uint)index))
-                    continue;
-            }
-            else
-            {
-                if (!ShouldFilter(config.DefaultConfig, entry.Value, (uint)index))
-                    continue;
-            }
-
-            entry.Value->RenderFlags |= (VisibilityFlags)256;
-            processedObjects.Add((nint)entry.Value);
+            isUpdatingObjects = false;
         }
     }
 
-    private static bool ShouldFilter(FilterConfig config, GameObject* gameObject, uint index)
+    private static bool IsActiveTerritory()
+    {
+        if (GameState.TerritoryIntendedUse == TerritoryIntendedUse.OccultCrescent)
+        {
+            // 在两歧塔里
+            return (LocalPlayerState.Object?.Position.Y ?? -100) >= 0;
+        }
+
+        return GameState.ContentFinderCondition == 0 &&
+               !GameState.IsInPVPArea                &&
+               GameState.TerritoryIntendedUse != TerritoryIntendedUse.IslandSanctuary;
+    }
+
+    private static bool HasActiveFilter(FilterConfig config) =>
+        config.HidePlayer || config.HidePet || config.HideChocobo || config.HideUnimportantENPC;
+
+    private bool ShouldFilter(FilterConfig config, GameObject* gameObject, uint index, bool isProcessed)
     {
         if (gameObject == null) return false;
 
         if (gameObject->EntityId == LocalPlayerState.EntityID) return false;
 
-        if (((RenderFlag)gameObject->RenderFlags).IsSet(RenderFlag.Invisible)) return false;
+        if (!isProcessed && ((RenderFlag)gameObject->RenderFlags).IsSet(RenderFlag.Invisible)) return false;
 
         if (gameObject->NamePlateIconId != 0) return false;
 
@@ -160,11 +363,7 @@ public unsafe class AutoHideGameObjects : ModuleBase
         {
             var player = (BattleChara*)gameObject;
 
-            if (player->IsFriend)
-                return false;
-
-            if (LocalPlayerState.IsInParty &&
-                (player->IsPartyMember || player->IsAllianceMember))
+            if (UpdatePlayerKeepStateAndShouldKeepVisible(config, player))
                 return false;
 
             return true;
@@ -206,51 +405,57 @@ public unsafe class AutoHideGameObjects : ModuleBase
         return false;
     }
 
-    private bool ShouldFilterOccultCrescent(GameObject* gameObject, nint targetAddress, ref int playerCount, uint index)
+    private bool ShouldFilterOccultCrescent(GameObject* gameObject, ref int playerCount, uint index, bool isProcessed)
     {
         if (gameObject == null) return false;
 
         if (gameObject->EntityId == LocalPlayerState.EntityID) return false;
 
+        if (!isProcessed && ((RenderFlag)gameObject->RenderFlags).IsSet(RenderFlag.Invisible)) return false;
+
         if (gameObject->NamePlateIconId != 0) return false;
 
         // 玩家
-        if (index                  <= 200 &&
+        if (config.DefaultConfig.HidePlayer &&
+            index                  <= 200 &&
             index % 2              == 0   &&
             gameObject->ObjectKind == ObjectKind.Pc)
         {
             var player = (BattleChara*)gameObject;
 
-            playerCount++;
-
-            if (player->IsDead() || (nint)gameObject == targetAddress)
-            {
-                gameObject->RenderFlags &= ~(VisibilityFlags)256;
-                processedObjects.Remove((nint)gameObject);
-                return false;
-            }
-
-            if (player->IsFriend)
+            if (player->IsDead())
                 return false;
 
-            if (LocalPlayerState.IsInParty &&
-                (player->IsPartyMember || player->IsAllianceMember))
+            if (UpdatePlayerKeepStateAndShouldKeepVisible(config.DefaultConfig, player))
                 return false;
 
-            return playerCount >= 10;
+            return ++playerCount > OCCULT_VISIBLE_PLAYER_LIMIT;
         }
 
         // 不重要 NPC
-        if (index is >= 489 and <= 629                                              &&
+        if (config.DefaultConfig.HideUnimportantENPC                                &&
+            index is >= 489 and <= 629                                              &&
             !gameObject->TargetableStatus.IsSet(ObjectTargetableFlags.IsTargetable) &&
             gameObject->EventHandler == null)
             return true;
 
         // 其他玩家的召唤物
-        if (gameObject->ObjectKind == ObjectKind.BattleNpc      &&
+        if (config.DefaultConfig.HidePet                        &&
+            gameObject->ObjectKind == ObjectKind.BattleNpc      &&
+            (BattleNpcSubKind)gameObject->SubKind == BattleNpcSubKind.Pet &&
             index                  <= 200                       &&
             index % 2              == 0                         &&
+            gameObject->OwnerId    != LocalPlayerState.EntityID &&
+            gameObject->OwnerId    != 0                         &&
+            gameObject->OwnerId    != 0xE0000000)
+            return true;
+
+        // 陆行鸟
+        if (config.DefaultConfig.HideChocobo                    &&
             gameObject->ObjectKind == ObjectKind.BattleNpc      &&
+            (BattleNpcSubKind)gameObject->SubKind == BattleNpcSubKind.Buddy &&
+            index                  <= 200                       &&
+            index % 2              == 0                         &&
             gameObject->OwnerId    != LocalPlayerState.EntityID &&
             gameObject->OwnerId    != 0                         &&
             gameObject->OwnerId    != 0xE0000000)
@@ -259,40 +464,406 @@ public unsafe class AutoHideGameObjects : ModuleBase
         return false;
     }
 
+    private static bool ShouldFilterPlayerRace(FilterConfig config, BattleChara* player)
+    {
+        if (config.RaceFilterMode == RaceFilterMode.Disabled)
+            return true;
+
+        var containsSelection = MatchesPlayerRaceSexFilter(config, player);
+
+        return config.RaceFilterMode switch
+        {
+            RaceFilterMode.HideSelected    => containsSelection,
+            RaceFilterMode.HideNotSelected => !containsSelection,
+            _                              => true
+        };
+    }
+
+    private bool UpdatePlayerKeepStateAndShouldKeepVisible(FilterConfig config, BattleChara* player)
+    {
+        if (player->IsFriend)
+            return true;
+
+        if (LocalPlayerState.IsInParty &&
+            (player->IsPartyMember || player->IsAllianceMember))
+            return true;
+
+        return IsTargetOrFocusPlayerKept(config, player)                  ||
+               IsTargetingMePlayerKept(config, player)                    ||
+               config.KeepRecruitingPlayers && IsRecruitingPlayer(player) ||
+               IsNearbyPlayerKept(config, player)                         ||
+               !ShouldFilterPlayerRace(config, player);
+    }
+
+    private static bool MatchesPlayerRaceSexFilter(FilterConfig config, BattleChara* player)
+    {
+        if (config.RaceSexFilter.Count == 0)
+            return false;
+
+        var customizeData = player->DrawData.CustomizeData;
+        return config.RaceSexFilter.Contains(PackRaceSex(customizeData.Race, customizeData.Sex));
+    }
+
+    private bool IsRecruitingPlayer(BattleChara* player)
+    {
+        return player != null && player->OnlineStatus == RECRUITING_ONLINE_STATUS_ID;
+    }
+
+    private bool IsTargetOrFocusPlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepTargetAndFocusPlayers || player == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        if (IsTargetOrFocusPlayer((GameObject*)player))
+        {
+            recentTargetPlayers[playerID] = Environment.TickCount64 + RECENT_TARGET_PLAYER_KEEP_MS;
+            return true;
+        }
+
+        if (!recentTargetPlayers.TryGetValue(playerID, out var expireTime))
+            return false;
+
+        if (expireTime > Environment.TickCount64)
+            return true;
+
+        recentTargetPlayers.Remove(playerID);
+        return false;
+    }
+
+    private static bool IsTargetOrFocusPlayer(GameObject* gameObject)
+    {
+        if (gameObject == null)
+            return false;
+
+        var address = (nint)gameObject;
+        return address == (TargetManager.Target?.Address ?? nint.Zero) ||
+               address == (TargetManager.FocusTarget?.Address ?? nint.Zero);
+    }
+
+    private bool IsTargetingMePlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepPlayersTargetingMe || player == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        var localPlayerID = GetLocalPlayerGameObjectID();
+        if (localPlayerID == 0)
+            return false;
+
+        var now = Environment.TickCount64;
+        if ((ulong)player->GetTargetId() == localPlayerID)
+        {
+            targetingMePlayers[playerID] = now + TARGETING_ME_PLAYER_KEEP_MS;
+            return true;
+        }
+
+        if (!targetingMePlayers.TryGetValue(playerID, out var expireTime))
+            return false;
+
+        if (expireTime > now)
+            return true;
+
+        targetingMePlayers.Remove(playerID);
+        return false;
+    }
+
+    private bool IsNearbyPlayerKept(FilterConfig config, BattleChara* player)
+    {
+        if (!config.KeepNearbyPlayers || player == null)
+            return false;
+
+        var localPlayer = LocalPlayerState.Object;
+        if (localPlayer == null)
+            return false;
+
+        var playerID = GetPlayerTrackingID(player);
+        if (playerID == 0)
+            return false;
+
+        var range = Math.Clamp(config.KeepNearbyPlayersRange, 1f, 50f);
+        var distanceSq = Vector3.DistanceSquared(localPlayer.Position, player->Position);
+
+        if (nearbyKeptPlayers.Contains(playerID))
+        {
+            var exitRange = range + NEARBY_PLAYER_RANGE_HYSTERESIS;
+            if (distanceSq <= exitRange * exitRange)
+                return true;
+
+            nearbyKeptPlayers.Remove(playerID);
+            return false;
+        }
+
+        if (distanceSq > range * range)
+            return false;
+
+        nearbyKeptPlayers.Add(playerID);
+        return true;
+    }
+
+    private static ulong GetPlayerTrackingID(BattleChara* player)
+    {
+        if (player == null)
+            return 0;
+
+        if (player->ContentId != 0)
+            return player->ContentId;
+
+        return (ulong)((GameObject*)player)->GetGameObjectId();
+    }
+
+    private static ulong GetLocalPlayerGameObjectID() =>
+        LocalPlayerState.Object?.GameObjectID ?? 0;
+
+    private static void TrackNearbyPlayer(GameObject* gameObject, uint index, HashSet<ulong>? seenNearbyPlayers)
+    {
+        if (seenNearbyPlayers == null ||
+            gameObject        == null ||
+            index             > 200   ||
+            index % 2         != 0    ||
+            gameObject->ObjectKind != ObjectKind.Pc)
+            return;
+
+        var playerID = GetPlayerTrackingID((BattleChara*)gameObject);
+        if (playerID != 0)
+            seenNearbyPlayers.Add(playerID);
+    }
+
+    private void SaveConfigAndRefresh()
+    {
+        config.Save(this);
+        nearbyKeptPlayers.Clear();
+        targetingMePlayers.Clear();
+        recentTargetPlayers.Clear();
+        ResetAllObjects();
+        UpdateAllObjects(GameObjectManager.Instance());
+    }
+
+    private static string GetRaceName(byte race)
+    {
+        if (!LuminaGetter.TryGetRow(race, out Race raceRow))
+            return Lang.Get("Unknown");
+
+        return raceRow.Masculine.ToString() ?? Lang.Get("Unknown");
+    }
+
+    private static string GetSexName(byte sex) =>
+        sex == FEMALE_SEX
+            ? LuminaWrapper.GetAddonText(15609)
+            : LuminaWrapper.GetAddonText(15608);
+
+    private static string GetRaceFilterModeName(RaceFilterMode mode) =>
+        mode switch
+        {
+            RaceFilterMode.HideSelected    => Lang.Get("AutoHideGameObjects-RaceFilterMode-HideSelected"),
+            RaceFilterMode.HideNotSelected => Lang.Get("AutoHideGameObjects-RaceFilterMode-HideNotSelected"),
+            _                              => Lang.Get("AutoHideGameObjects-RaceFilterMode-Disabled")
+        };
+
+    private static void SetRaceSexFilter(FilterConfig config, byte race, byte sex, bool selected)
+    {
+        var value = PackRaceSex(race, sex);
+
+        if (selected)
+            config.RaceSexFilter.Add(value);
+        else
+            config.RaceSexFilter.Remove(value);
+    }
+
+    private static void SetAllRaceSexFilters(FilterConfig config, bool selected)
+    {
+        config.RaceSexFilter.Clear();
+        if (!selected) return;
+
+        for (var race = MIN_RACE; race <= MAX_RACE; race++)
+        for (var sex = MALE_SEX; sex <= FEMALE_SEX; sex++)
+            config.RaceSexFilter.Add(PackRaceSex((byte)race, (byte)sex));
+    }
+
+    private static void InvertRaceSexFilters(FilterConfig config)
+    {
+        for (var race = MIN_RACE; race <= MAX_RACE; race++)
+        for (var sex = MALE_SEX; sex <= FEMALE_SEX; sex++)
+        {
+            var value = PackRaceSex((byte)race, (byte)sex);
+
+            if (!config.RaceSexFilter.Remove(value))
+                config.RaceSexFilter.Add(value);
+        }
+    }
+
+    private static byte PackRaceSex(byte race, byte sex) =>
+        (byte)(race | sex << 4);
+
+    private void HideObject(GameObject* gameObject)
+    {
+        if (gameObject == null) return;
+
+        gameObject->RenderFlags |= (VisibilityFlags)256;
+        processedObjects[(nint)gameObject] = HiddenObjectRecord.From(gameObject);
+    }
+
+    private bool IsProcessedObject(GameObject* gameObject)
+    {
+        if (gameObject == null) return false;
+
+        var address = (nint)gameObject;
+        if (!processedObjects.TryGetValue(address, out var record))
+            return false;
+
+        if (record.IsSameObject(gameObject))
+            return true;
+
+        processedObjects.Remove(address);
+        return false;
+    }
+
+    private void RestoreObjectIfProcessed(GameObject* gameObject)
+    {
+        if (gameObject == null) return;
+
+        var address = (nint)gameObject;
+        if (!processedObjects.TryGetValue(address, out var record))
+            return;
+
+        processedObjects.Remove(address);
+
+        if (!record.IsSameObject(gameObject))
+            return;
+
+        gameObject->RenderFlags &= ~(VisibilityFlags)256;
+    }
+
+    private void RestoreStaleProcessedObjects(GameObjectManager* manager, HashSet<nint> seenProcessed)
+    {
+        if (processedObjects.Count == 0) return;
+
+        foreach (var address in processedObjects.Keys.ToArray())
+        {
+            if (seenProcessed.Contains(address))
+                continue;
+
+            if (TryFindObject(manager, address, processedObjects[address], out var gameObject))
+                gameObject->RenderFlags &= ~(VisibilityFlags)256;
+
+            processedObjects.Remove(address);
+        }
+    }
+
+    private static bool TryFindObject(GameObjectManager* manager, nint address, HiddenObjectRecord record, out GameObject* gameObject)
+    {
+        gameObject = null;
+        if (manager == null || address == nint.Zero)
+            return false;
+
+        foreach (ref var entry in manager->Objects.IndexSorted)
+        {
+            if ((nint)entry.Value != address || !record.IsSameObject(entry.Value))
+                continue;
+
+            gameObject = entry.Value;
+            return true;
+        }
+
+        return false;
+    }
+
+    private void RemoveStaleNearbyKeptPlayers(HashSet<ulong>? seenNearbyPlayers)
+    {
+        if (nearbyKeptPlayers.Count == 0)
+            return;
+
+        if (seenNearbyPlayers == null)
+        {
+            nearbyKeptPlayers.Clear();
+            return;
+        }
+
+        foreach (var playerID in nearbyKeptPlayers.ToArray())
+        {
+            if (!seenNearbyPlayers.Contains(playerID))
+                nearbyKeptPlayers.Remove(playerID);
+        }
+    }
+
     private void ResetAllObjects()
     {
-        if (!DService.Instance().ClientState.IsLoggedIn || processedObjects.Count == 0) return;
+        if (processedObjects.Count == 0) return;
+
+        if (!DService.Instance().ClientState.IsLoggedIn)
+        {
+            ClearProcessedObjects();
+            return;
+        }
 
         var manager = GameObjectManager.Instance();
-        if (manager == null) return;
+        if (manager == null)
+        {
+            ClearProcessedObjects();
+            return;
+        }
 
         foreach (ref var entry in GameObjectManager.Instance()->Objects.IndexSorted)
         {
             if (entry.Value       == null                                            ||
                 (nint)entry.Value == (LocalPlayerState.Object?.Address ?? nint.Zero) ||
-                !processedObjects.Contains((nint)entry.Value))
+                !processedObjects.TryGetValue((nint)entry.Value, out var record)     ||
+                !record.IsSameObject(entry.Value))
                 continue;
 
             entry.Value->RenderFlags &= ~(VisibilityFlags)256;
         }
 
-        processedObjects.Clear();
-        zoneUpdateCount = 0;
+        ClearProcessedObjects();
     }
 
     private void OnZoneChanged(uint u)
     {
-        zoneUpdateCount = 0;
-        processedObjects.Clear();
+        ResetAllObjects();
+        ClearProcessedObjects();
     }
 
     private void OnUpdate(IFramework _)
     {
-        // 主要是小区域更新不及时
-        if (zoneUpdateCount > 3 || DService.Instance().Condition.IsBetweenAreas) return;
+        if (DService.Instance().Condition.IsBetweenAreas) return;
 
-        zoneUpdateCount++;
+        PruneTargetingMePlayers();
+        PruneRecentTargetPlayers();
         UpdateAllObjects(GameObjectManager.Instance());
+    }
+
+    private void PruneTargetingMePlayers()
+    {
+        if (targetingMePlayers.Count == 0)
+            return;
+
+        var now = Environment.TickCount64;
+        foreach (var playerID in targetingMePlayers.Where(x => x.Value <= now).Select(x => x.Key).ToArray())
+            targetingMePlayers.Remove(playerID);
+    }
+
+    private void PruneRecentTargetPlayers()
+    {
+        if (recentTargetPlayers.Count == 0)
+            return;
+
+        var now = Environment.TickCount64;
+        foreach (var playerID in recentTargetPlayers.Where(x => x.Value <= now).Select(x => x.Key).ToArray())
+            recentTargetPlayers.Remove(playerID);
+    }
+
+    private void ClearProcessedObjects()
+    {
+        processedObjects.Clear();
+        nearbyKeptPlayers.Clear();
+        targetingMePlayers.Clear();
+        recentTargetPlayers.Clear();
     }
     
     private class Config : ModuleConfig
@@ -311,8 +882,46 @@ public unsafe class AutoHideGameObjects : ModuleBase
         // 玩家
         public bool HidePlayer = true;
 
+        // 保留正在队员招募中的玩家
+        public bool KeepRecruitingPlayers = true;
+
+        // 保留一定距离内的玩家
+        public bool KeepNearbyPlayers;
+
+        public float KeepNearbyPlayersRange = 5f;
+
+        // 保留自己的目标和焦点目标
+        public bool KeepTargetAndFocusPlayers = true;
+
+        // 保留一段时间内以自己为目标的玩家
+        public bool KeepPlayersTargetingMe = true;
+
+        // 玩家种族过滤模式
+        public RaceFilterMode RaceFilterMode = RaceFilterMode.Disabled;
+
+        // 玩家种族 / 性别过滤列表
+        public HashSet<byte> RaceSexFilter = [];
+
         // 不重要 NPC
         public bool HideUnimportantENPC = true;
+    }
+
+    public enum RaceFilterMode
+    {
+        Disabled,
+        HideSelected,
+        HideNotSelected
+    }
+
+    private readonly record struct HiddenObjectRecord(ulong GameObjectID, uint EntityID)
+    {
+        public static HiddenObjectRecord From(GameObject* gameObject) =>
+            new((ulong)gameObject->GetGameObjectId(), gameObject->EntityId);
+
+        public bool IsSameObject(GameObject* gameObject) =>
+            gameObject != null &&
+            (ulong)gameObject->GetGameObjectId() == GameObjectID &&
+            gameObject->EntityId                 == EntityID;
     }
 
     private enum RenderFlag


### PR DESCRIPTION
## 变更内容

完善 `AutoHideGameObjects` 模块的玩家隐藏规则与配置体验。

<img width="1118" height="823" alt="Snipaste_2026-06-03_16-15-06" src="https://github.com/user-attachments/assets/f8b066ea-e478-4605-8e1a-4433900345cb" />

### 新增规则

- 支持按玩家种族 + 性别，正反向过滤隐藏对象
- 新增玩家保留规则
  - 正在队员招募中的玩家不会被隐藏
  - 身边一定范围内的玩家不会被隐藏
  - 当前目标 / 焦点目标不会被隐藏（检测到后保留 30 秒）
  - 以自己为目标的玩家不会被隐藏（检测到后保留 60 秒）

### 行为修正

- 修复切区、对象后加载、对象消失 / 复用时隐藏状态可能不及时更新的问题
- 隐藏记录从单纯地址集合改为包含 `GameObjectID + EntityID` 的记录，降低地址复用导致误恢复的风险
- 对已由本模块隐藏的对象，在后续不再满足规则时会恢复显示
- 对本来就是游戏 / 其他逻辑隐藏的对象，不会纳入本模块管理，避免误清除原生 Invisible flag
- Occult Crescent 分支现在与普通区域保持配置语义一致；玩家隐藏预算调整为保留前 10 个普通玩家，从第 11 个开始隐藏

### 本地化

- 新增简体中文本地化 key
- 其他语言按当前本地化仓要求暂不修改

## 配置兼容性

旧配置仍可正常加载。新增字段均有默认值：

- `KeepRecruitingPlayers = true`
- `KeepNearbyPlayers = false`
- `KeepNearbyPlayersRange = 5f`
- `KeepTargetAndFocusPlayers = true`
- `KeepPlayersTargetingMe = true`
- `RaceFilterMode = Disabled`
- `RaceSexFilter = []`

需要注意：部分新增保留规则默认开启，因此旧用户在启用“隐藏玩家”时，可能会看到以下玩家不再被隐藏：

- 正在队员招募中的玩家
- 当前 / 最近目标或焦点目标
- 近期以自己为目标的玩家

## 验证

- [x] 构建通过
- [x] 已本地验证配置文件可加载
- [x] 简体中文本地化 JSON 验证 OK <https://github.com/Dalamud-DailyRoutines/DailyRoutines.Localizations/pull/139>