### PR TITLE
fix AutoIgnoreLoginLock 在排队时的画面闪烁问题

### DIFF
--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -56,7 +56,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         ]
     );
 
-    // 对应排队提示（Error 13206）的 SelectOk：将创建参数中的 filter 标记从 01 改为 00
+    // 对应登录错误提示的 SelectOk（Error 13206 或 Error 13214）：将创建参数中的 filter 标记从 01 改为 00
     private readonly MemoryPatch queueSelectOkNoFilterPatch = new
     (
         "01 4C 8B CE 44 88 64 24 40 4C 8B C3 44 88 64 24 38 48 8B D0 C7 44 24 30 0A 00 00 00 48 8B CF 66 44 89 64 24 28 48 C7 44 24 20 1E 00 00 00 E8 ?? ?? ?? ?? 4C 8B BC 24",

--- a/System/AutoIgnoreLoginLock.cs
+++ b/System/AutoIgnoreLoginLock.cs
@@ -56,6 +56,13 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         ]
     );
 
+    // 对应排队提示（Error 13206）的 SelectOk：将创建参数中的 filter 标记从 01 改为 00
+    private readonly MemoryPatch queueSelectOkNoFilterPatch = new
+    (
+        "01 4C 8B CE 44 88 64 24 40 4C 8B C3 44 88 64 24 38 48 8B D0 C7 44 24 30 0A 00 00 00 48 8B CF 66 44 89 64 24 28 48 C7 44 24 20 1E 00 00 00 E8 ?? ?? ?? ?? 4C 8B BC 24",
+        [0x00]
+    );
+
     protected override void Init()
     {
         AgentLobbyUpdateHook = AgentLobby.Instance()->VirtualTable->HookVFuncFromName("Update", (AgentLobby.Delegates.Update)AgentLobbyUpdateDetour);
@@ -70,6 +77,7 @@ public unsafe class AutoIgnoreLoginLock : ModuleBase
         PlaySystemSoundHook.Enable();
         
         loginFallbackPatch.Enable();
+        queueSelectOkNoFilterPatch.Enable();
     }
 
     private void AgentLobbyUpdateDetour(AgentLobby* agent, uint deltaTime)


### PR DESCRIPTION
改动：
Patch 对应登录错误提示的 SelectOk 的创建参数，使它被创建时不带遮罩，也就不会影响画面亮度从而导致画面闪烁了。

测试：
排队时，模块原功能正常生效。
在手动取消排队后，所有交互和画面正常。

影响的 SelectOk 当前对应以下文本 ：
> Error 13206: 
> 当前服务器繁忙，需要排队进行登录，请耐心等待。
> （当前排队人数：<Format(IntegerParameter(1),FF022C)/>人）
> Error 13214: 
> 上次该角色退出时系统出现异常，或正在通过其他客户端登录，已强制令该角色下线。
> 稍等片刻即可进行重新登录。