### PR TITLE
拆分时尚配饰隐藏配置

### DIFF
--- a/System/AutoHideGameObjects.cs
+++ b/System/AutoHideGameObjects.cs
@@ -74,6 +74,10 @@ public unsafe class AutoHideGameObjects : ModuleBase
                 config.Save(this);
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HidePetHelp"));
 
+            if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideOrnament"), ref config.DefaultConfig.HideOrnament))
+                config.Save(this);
+            ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideOrnamentHelp"));
+
             if (ImGui.Checkbox(Lang.Get("AutoHideGameObjects-HideChocobo"), ref config.DefaultConfig.HideChocobo))
                 config.Save(this);
             ImGuiOm.TooltipHover(Lang.Get("AutoHideGameObjects-HideChocoboHelp"));
@@ -171,10 +175,18 @@ public unsafe class AutoHideGameObjects : ModuleBase
         }
 
         // 宠物
-        if (config.HidePet                             &&
-            index                  <= 200              &&
-            index % 2              == 1                &&
-            gameObject->ObjectKind != ObjectKind.Mount &&
+        if (config.HidePet                                 &&
+            index                  <= 200                  &&
+            index % 2              == 1                    &&
+            gameObject->ObjectKind == ObjectKind.Companion &&
+            gameObject->OwnerId    != LocalPlayerState.EntityID)
+            return true;
+
+        // 时尚配饰
+        if (config.HideOrnament                           &&
+            index                  <= 200                 &&
+            index % 2              == 1                   &&
+            gameObject->ObjectKind == ObjectKind.Ornament &&
             gameObject->OwnerId    != LocalPlayerState.EntityID)
             return true;
         
@@ -307,6 +319,9 @@ public unsafe class AutoHideGameObjects : ModuleBase
 
         // 宠物
         public bool HidePet = true;
+
+        // 时尚配饰
+        public bool HideOrnament = true;
 
         // 玩家
         public bool HidePlayer = true;


### PR DESCRIPTION
AutoHideGameObjects 模块

从 HidePet 选项里把隐藏时尚配饰的副作用拆出来。

变更依据：HidePet 功能的实现和描述不统一，可能引起误解。

具体变更：改为按 ObjectKind.Companion 和 ObjectKind.Ornament 判定：
<img width="739" height="990" alt="image" src="https://github.com/user-attachments/assets/20fb50e7-34c5-416f-9169-882aef80c631" />

兼容性：新的隐藏时尚配饰功能默认开启（因为本模块其他功能也是默认开启），出于代码简洁考虑不做从 HidePet 的配置迁移。

翻译：<https://github.com/Dalamud-DailyRoutines/DailyRoutines.Localizations/pull/140>